### PR TITLE
Add python magic to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     author_email="peter@trailofbits.com",
     url="https://github.com/lifting-bits/anvill",
     license="AGPL 3",
+    install_requires=["python-magic"],
     py_modules=[
         "anvill.__init__", "anvill.__main__", "anvill.arch", "anvill.binja",
         "anvill.dwarf", "anvill.dwarf_type", "anvill.exc",


### PR DESCRIPTION
`magic` is a dependency of anvill and isn't currently installed with setup.py 

This PR adds it to setup.py so `python setup.py install` adds all dependencies.  