### PR TITLE
Carson/type reg test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ set(ROUNDTRIP_TEST_FILES
   tests/trunc.c
   tests/zeroinit.c
   tests/zext.c
+  tests/binja_var_none_type.c
 )
 
 install(

--- a/python/anvill/binja.py
+++ b/python/anvill/binja.py
@@ -378,6 +378,8 @@ class BNFunction(Function):
         elif isinstance(item_or_list, mlinst):
             results.extend(self._extract_types_mlil(bv, item_or_list.operands, initial_inst))
         elif isinstance(item_or_list, bn.Variable):
+            if item_or_list.type is None:
+                return results
             # We only care about registers that represent pointers.
             if item_or_list.type.type_class == bn.TypeClass.PointerTypeClass:
                 if item_or_list.source_type == bn.VariableSourceType.RegisterVariableSourceType:

--- a/tests/binja_var_none_type.c
+++ b/tests/binja_var_none_type.c
@@ -1,0 +1,22 @@
+/*
+* This test causes BinaryNinja to produce Variables with None type
+* This should be handled in extract_types
+*/
+void xor_swap(unsigned char buf[]) {
+  buf[0] = buf[0] ^ buf[1];
+  buf[1] = buf[0] ^ buf[1];
+  buf[0] = buf[0] ^ buf[1];  
+}
+//Simple atoi
+unsigned char atoi(const char * s) {
+ return s[0] - '0';
+}
+int main(int argc, const char *argv[]) {	
+  unsigned char buf[3] = {9, 10, 11};
+  int buff_size = sizeof(buf)/sizeof(buf[0]);
+  for(int i = 1; i < argc && i < buff_size; i++) {
+    buf[i - 1] = (unsigned char)atoi(argv[i]);
+  }
+  xor_swap(buf);
+  return 0;
+}


### PR DESCRIPTION
This PR adds a regression test for #89 and also found a new bug in extract_types where binja emits None for a variable type. 