### PR TITLE
Handling of missing type class

### DIFF
--- a/python/anvill/__main__.py
+++ b/python/anvill/__main__.py
@@ -15,9 +15,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import sys
 import argparse
 import json
 
+from .util import INIT_DEBUG_FILE
 from .binja import get_program
 
 
@@ -43,7 +46,16 @@ def main():
         default=False,
     )
 
+    arg_parser.add_argument(
+        "--log_file",
+        type=argparse.FileType('w'), default=os.devnull,
+        help="Log to a specific file."
+    )
+
     args = arg_parser.parse_args()
+
+    if args.log_file != os.devnull:
+        INIT_DEBUG_FILE(args.log_file)
 
     p = get_program(args.bin_in)
 

--- a/python/anvill/util.py
+++ b/python/anvill/util.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 Trail of Bits, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+_DEBUG_FILE = None
+_DEBUG_PREFIX = ""
+
+def INIT_DEBUG_FILE(file):
+	global _DEBUG_FILE
+	_DEBUG_FILE = file
+
+def DEBUG_PUSH():
+	global _DEBUG_PREFIX
+	_DEBUG_PREFIX += "  "
+
+def DEBUG_POP():
+	global _DEBUG_PREFIX
+	_DEBUG_PREFIX = _DEBUG_PREFIX[:-2]
+
+def DEBUG(s):
+	global _DEBUG_FILE
+	if _DEBUG_FILE:
+		_DEBUG_FILE.write("{}{}\n".format(_DEBUG_PREFIX, str(s)))

--- a/python/anvill/var.py
+++ b/python/anvill/var.py
@@ -44,5 +44,7 @@ class Variable(object):
     def proto(self):
         proto = {}
         proto["address"] = self.address()
-        proto["type"] = self.type().proto(self._arch)
+        if self.type() != None:
+            proto["type"] = self.type().proto(self._arch)
+
         return proto

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,4 @@ setuptools.setup(
         "anvill.__init__", "anvill.__main__", "anvill.arch", "anvill.binja",
         "anvill.exc", "anvill.function", "anvill.ida", "anvill.loc",
         "anvill.mem", "anvill.os", "anvill.program", "anvill.type",
-        "anvill.var"])
+        "anvill.var", "anvill.util"])


### PR DESCRIPTION
Add warning logs for type classes that are not handled. Added checks if binja fails to get segment information for some variable address such as  `__elf_headers`.