### PR TITLE
Handling of Named Type references

### DIFF
--- a/lib/Lift.cpp
+++ b/lib/Lift.cpp
@@ -24,6 +24,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Utils.h>
+
+#include <remill/BC/Compat/VectorType.h>
 #include <remill/BC/Util.h>
 
 #include <algorithm>
@@ -593,7 +595,7 @@ CreateConstFromMemory(const uint64_t addr, llvm::Type *type,
       result = llvm::ConstantArray::get(array_type, initializer_list);
     } break;
 
-    case llvm::Type::FixedVectorTyID: {
+    case llvm::GetFixedVectorTypeId(): {
       const auto vec_type = llvm::dyn_cast<llvm::FixedVectorType>(type);
       const auto num_elms = vec_type->getNumElements();
       const auto elm_type = vec_type->getElementType();

--- a/lib/Lift.cpp
+++ b/lib/Lift.cpp
@@ -510,6 +510,7 @@ namespace {
 static llvm::APInt ReadValueFromMemory(const uint64_t addr, const uint64_t size,
                                        const remill::Arch *arch,
                                        const Program &program) {
+
   // create an instance of precision integer of size*8 bits
   llvm::APInt result(size * 8, 0);
   for (auto i = 0u; i < size; ++i) {
@@ -525,7 +526,7 @@ static llvm::APInt ReadValueFromMemory(const uint64_t addr, const uint64_t size,
   }
 
   // NOTE(artem): LLVM's APInt does not handle byteSwap()
-  // for size 8, leading to a segfault. Guard against it here.
+  // for size 1, leading to a segfault. Guard against it here.
   if (arch->MemoryAccessIsLittleEndian() && size > 1) {
     result = result.byteSwap();
   }
@@ -563,15 +564,14 @@ CreateConstFromMemory(const uint64_t addr, llvm::Type *type,
       std::vector<llvm::Constant *> initializer_list;
       initializer_list.reserve(num_elms);
 
-      for (std::uint64_t i = 0U; i < num_elms; ++i) {
+      for (auto i = 0U; i < num_elms; ++i) {
         const auto elm_type = struct_type->getStructElementType(i);
         const auto offset = layout->getElementOffset(i);
-        auto const_elm = CreateConstFromMemory(addr + offset, elm_type,
-                                               arch, program, module);
+        auto const_elm = CreateConstFromMemory(addr + offset, elm_type, arch,
+                                               program, module);
         initializer_list.push_back(const_elm);
       }
-      result = llvm::ConstantStruct::get(struct_type,
-                                         llvm::ArrayRef(initializer_list));
+      result = llvm::ConstantStruct::get(struct_type, initializer_list);
     } break;
 
     case llvm::Type::ArrayTyID: {

--- a/lib/Lift.cpp
+++ b/lib/Lift.cpp
@@ -510,8 +510,9 @@ namespace {
 static llvm::APInt ReadValueFromMemory(const uint64_t addr, const uint64_t size,
                                        const remill::Arch *arch,
                                        const Program &program) {
-  llvm::APInt result(size, 0);
-  for (auto i = 0u; i < (size / 8); ++i) {
+  // create an instance of precision integer of size*8 bits
+  llvm::APInt result(size * 8, 0);
+  for (auto i = 0u; i < size; ++i) {
     auto byte_val = program.FindByte(addr + i).Value();
     if (remill::IsError(byte_val)) {
       LOG(ERROR) << "Unable to read value of byte at " << std::hex << addr + i
@@ -525,7 +526,7 @@ static llvm::APInt ReadValueFromMemory(const uint64_t addr, const uint64_t size,
 
   // NOTE(artem): LLVM's APInt does not handle byteSwap()
   // for size 8, leading to a segfault. Guard against it here.
-  if (arch->MemoryAccessIsLittleEndian() && size > 8) {
+  if (arch->MemoryAccessIsLittleEndian() && size > 1) {
     result = result.byteSwap();
   }
 
@@ -540,59 +541,56 @@ CreateConstFromMemory(const uint64_t addr, llvm::Type *type,
   llvm::Constant *result{nullptr};
   switch (type->getTypeID()) {
     case llvm::Type::IntegerTyID: {
-      const auto size = dl.getTypeSizeInBits(type);
+      const auto size = dl.getTypeAllocSize(type);
       auto val = ReadValueFromMemory(addr, size, arch, program);
       result = llvm::ConstantInt::get(type, val);
     } break;
 
     case llvm::Type::PointerTyID: {
+      const auto pointer_type = llvm::dyn_cast<llvm::PointerType>(type);
+      const auto size = dl.getTypeAllocSize(type);
+      auto val = ReadValueFromMemory(addr, size, arch, program);
+      result = llvm::Constant::getIntegerValue(pointer_type, val);
     } break;
 
     case llvm::Type::StructTyID: {
+
       // Take apart the structure type, recursing into each element
       // so that we can create a constant structure
-      auto struct_type = llvm::dyn_cast<llvm::StructType>(type);
-
-      auto num_elms = struct_type->getNumElements();
-      auto elm_offset = 0;
-
-      std::vector<llvm::Constant *> const_list;
+      const auto struct_type = llvm::dyn_cast<llvm::StructType>(type);
+      const auto layout = dl.getStructLayout(struct_type);
+      const auto num_elms = struct_type->getStructNumElements();
+      std::vector<llvm::Constant *> initializer_list;
+      initializer_list.reserve(num_elms);
 
       for (std::uint64_t i = 0U; i < num_elms; ++i) {
-        auto elm_type = struct_type->getElementType(i);
-        auto elm_size = dl.getTypeSizeInBits(elm_type);
-
-        auto const_elm =
-            CreateConstFromMemory(addr + elm_offset, elm_type, arch,
-                                  program, module);
-
-        const_list.push_back(const_elm);
-        elm_offset += elm_size / 8;
+        const auto elm_type = struct_type->getStructElementType(i);
+        const auto offset = layout->getElementOffset(i);
+        auto const_elm = CreateConstFromMemory(addr + offset, elm_type,
+                                               arch, program, module);
+        initializer_list.push_back(const_elm);
       }
-
       result = llvm::ConstantStruct::get(struct_type,
-                                        llvm::ArrayRef(const_list));
+                                         llvm::ArrayRef(initializer_list));
     } break;
 
     case llvm::Type::ArrayTyID: {
+
+      // Traverse through all the elements of array and create the initializer
+      const auto array_type = llvm::dyn_cast<llvm::ArrayType>(type);
       const auto elm_type = type->getArrayElementType();
-      const auto elm_size = dl.getTypeSizeInBits(elm_type);
+      const auto elm_size = dl.getTypeAllocSize(elm_type);
       const auto num_elms = type->getArrayNumElements();
-      std::string bytes(dl.getTypeSizeInBits(type) / 8, '\0');
+      std::vector<llvm::Constant *> initializer_list;
+      initializer_list.reserve(num_elms);
+
       for (auto i = 0u; i < num_elms; ++i) {
-        const auto elm_offset = i * (elm_size / 8);
-        const auto src =
-            ReadValueFromMemory(addr + elm_offset, elm_size, arch, program)
-                .getRawData();
-        const auto dst = bytes.data() + elm_offset;
-        std::memcpy(dst, src, elm_size / 8);
+        const auto elm_offset = i * elm_size;
+        auto const_elm = CreateConstFromMemory(addr + elm_offset, elm_type,
+                                               arch, program, module);
+        initializer_list.push_back(const_elm);
       }
-      if (elm_size == 8) {
-        result = llvm::ConstantDataArray::getString(module.getContext(), bytes,
-                                                    /*AddNull=*/false);
-      } else {
-        result = llvm::ConstantDataArray::getRaw(bytes, num_elms, elm_type);
-      }
+      result = llvm::ConstantArray::get(array_type, initializer_list);
     } break;
 
     default:

--- a/python/anvill/binja.py
+++ b/python/anvill/binja.py
@@ -229,8 +229,10 @@ def _convert_named_type_reference(
 
 def _convert_bn_type(bv, tinfo: bn.types.Type, cache):
     """Convert an bn `Type` instance into a `Type` instance."""
-    if _cache_key(tinfo) in cache:
-        return cache[_cache_key(tinfo)]
+    
+    cache_key = _cache_key(tinfo)
+    if cache_key in cache:
+        return cache[cache_key]
 
     # Void type.
     if tinfo.type_class == bn.TypeClass.VoidTypeClass:
@@ -239,13 +241,13 @@ def _convert_bn_type(bv, tinfo: bn.types.Type, cache):
     # Pointer, array, or function.
     elif tinfo.type_class == bn.TypeClass.PointerTypeClass:
         ret = PointerType()
-        cache[_cache_key(tinfo)] = ret
+        cache[cache_key] = ret
         ret.set_element_type(_convert_bn_type(bv, tinfo.element_type, cache))
         return ret
 
     elif tinfo.type_class == bn.TypeClass.FunctionTypeClass:
         ret = FunctionType()
-        cache[_cache_key(tinfo)] = ret
+        cache[cache_key] = ret
         ret.set_return_type(_convert_bn_type(bv, tinfo.return_value, cache))
 
         for var in tinfo.parameters:
@@ -258,14 +260,14 @@ def _convert_bn_type(bv, tinfo: bn.types.Type, cache):
 
     elif tinfo.type_class == bn.TypeClass.ArrayTypeClass:
         ret = ArrayType()
-        cache[_cache_key(tinfo)] = ret
+        cache[cache_key] = ret
         ret.set_element_type(_convert_bn_type(bv, tinfo.element_type, cache))
         ret.set_num_elements(tinfo.count)
         return ret
 
     elif tinfo.type_class == bn.TypeClass.StructureTypeClass:
         ret = StructureType()
-        cache[_cache_key(tinfo)] = ret
+        cache[cache_key] = ret
 
         for elem in tinfo.structure.members:
             ret.add_element_type(_convert_bn_type(bv, elem.type, cache))
@@ -276,7 +278,7 @@ def _convert_bn_type(bv, tinfo: bn.types.Type, cache):
         # The underlying type of enum will be an Interger of size
         # tinfo.width
         ret = EnumType()
-        cache[_cache_key(tinfo)] = ret
+        cache[cache_key] = ret
         ret.set_underlying_type(IntegerType(tinfo.width, False))
         return ret
 


### PR DESCRIPTION
The PR fixes the handling of Named Type references in the binary. It recovers them as a block of bytes and lifts them. Recovering the elements of named types is still in the TODO list and will be handled in future PR. 