### PR TITLE
Handling of variables with invalid address

### DIFF
--- a/lib/Analyze.cpp
+++ b/lib/Analyze.cpp
@@ -515,7 +515,13 @@ uint64_t XrefExprFolder::VisitSExt(llvm::Value *op, llvm::Type *type) {
 uint64_t XrefExprFolder::VisitTrunc(llvm::Value *op, llvm::Type *type) {
   auto ea = Visit(op);
   const auto dest_size = type->getPrimitiveSizeInBits();
-  CHECK_LT(dest_size, 64u);
+
+  // return ea if dest type is not trucated
+  if (dest_size == 64u) {
+    return ea;
+  }
+
+  CHECK_LE(dest_size, 64u);
   const auto mask = (1ull << dest_size) - 1ull;
   return (ea & mask);
 }


### PR DESCRIPTION
The PR fixes the handling of variables with invalid addresses. It does not get added to the global variables list. Also, fixes the assertion error due to `unimplemented` or `undef` instructions as one of LLIL operand.