### PR TITLE
Only install to system packages if not doing a dev install

### DIFF
--- a/anvill/python/CMakeLists.txt
+++ b/anvill/python/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(setup_file_path "${PROJECT_SOURCE_DIR}/setup.py")
 
-if(ANVILL_ENABLE_INSTALL_TARGET)
+if(ANVILL_ENABLE_INSTALL_TARGET AND NOT ANVILL_INSTALL_PYTHON3_LIBS)
   install(
     FILES "${PROJECT_SOURCE_DIR}/anvill/plugins/ida/anvill.py"
     DESTINATION "share/anvill/ida"


### PR DESCRIPTION
Do not try to install to system packages if doing a dev install. Avoid the following error message:

```
running install
error: You must specify --record or --root when building system packages
```