### PR TITLE
CI: Update default CMake settings, fix package generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
           url="https://github.com/trailofbits/cxx-common/releases/download/${{ matrix.cxxcommon_version}}/${archive_name}"
           local_path="${{ steps.build_paths.outputs.DOWNLOADS }}/${archive_name}"
 
-          if [[ ! -f "${local_path}" ]]; then
+          if [[ ! -f "${local_path}" ]] ; then
             echo "Downloading: ${url}"
             curl "${url}" -L -o "${local_path}"
 
@@ -295,10 +295,9 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
 
         shell: bash
-        working-directory: ${{ steps.build_paths.outputs.BUILD }}
+        working-directory: ${{ steps.build_paths.outputs.BUILD }}/anvill_build
         run: |
-          cmake --build anvill_build \
-                --target test
+          ctest -V
  
       - name: Create the packages
         shell: bash
@@ -451,7 +450,7 @@ jobs:
           url="https://github.com/trailofbits/cxx-common/releases/download/${{ matrix.cxxcommon_version}}/${archive_name}"
           local_path="${{ steps.build_paths.outputs.DOWNLOADS }}/${archive_name}"
 
-          if [[ ! -f "${local_path}" ]]; then
+          if [[ ! -f "${local_path}" ]] ; then
             echo "Downloading: ${url}"
             curl "${url}" -L -o "${local_path}"
 

--- a/anvill/python/CMakeLists.txt
+++ b/anvill/python/CMakeLists.txt
@@ -15,7 +15,7 @@ if(ANVILL_ENABLE_INSTALL_TARGET AND NOT ANVILL_INSTALL_PYTHON3_LIBS)
   )
 
   install(CODE
-    "execute_process(COMMAND ${setup_file_path} install --single-version-externally-managed --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR})"
+    "execute_process(COMMAND ${setup_file_path} install --single-version-externally-managed --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR})"
   )
 endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -8,8 +8,8 @@
 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type")
 
-option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components")
-option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests")
+option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components" true)
+option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests" true)
 option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging")
 
 set(VCPKG_ROOT "" CACHE FILEPATH "Root directory to use for vcpkg-managed dependencies")


### PR DESCRIPTION
Changes:
1. Enables the tests and the install target in the default configuration
2. Fixes an issues with packaging, which didn't work correctly due to how DESTDIR was handled