### PR TITLE
Update build.yml to limit MacOS CI Runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macos-11.0' ]
-        llvm: [ '9', '10', '11' ]
+        llvm: [ '11' ]
         cxxcommon_version: [ 'v0.1.1' ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Limit MacOS to LLVM 11 since we have a limited number of MacOS runners.