### PR TITLE
Fix bytesequence and copypasta

### DIFF
--- a/anvill/include/anvill/Program.h
+++ b/anvill/include/anvill/Program.h
@@ -132,6 +132,10 @@ struct ByteSequence {
     return size;
   }
 
+  uint64_t Address(void) const {
+    return address;
+  }
+
   // Convert this byte sequence to a string.
   std::string_view ToString(void) const;
 

--- a/anvill/include/anvill/Program.h
+++ b/anvill/include/anvill/Program.h
@@ -128,11 +128,11 @@ struct ByteSequence {
     return first_data != nullptr;
   }
 
-  size_t Size(void) const {
+  inline size_t Size(void) const {
     return size;
   }
 
-  uint64_t Address(void) const {
+  inline uint64_t Address(void) const {
     return address;
   }
 

--- a/anvill/src/Analyze.cpp
+++ b/anvill/src/Analyze.cpp
@@ -1085,15 +1085,15 @@ llvm::Constant *GetAddress(const Program &program, llvm::Module &module,
   } else if (auto bytes = program.FindBytesContaining(ea); bytes) {
     DLOG(INFO) << "Found a byte inside a memory area at: " << std::hex << ea
                << std::dec;
-    auto start_address = bytes[0].Address();
+    auto start_address = bytes.Address();
     auto var_name = CreateVariableName(start_address);
     auto data = bytes.ToString();
     auto init_data = llvm::ConstantDataArray::get(
         module.getContext(), llvm::makeArrayRef(data.data(), data.size()));
     auto var_type = init_data->getType();
 
-    auto ret = module.getOrInsertGlobal(var_name, var_type);
-    if (auto gv = llvm::dyn_cast<llvm::GlobalVariable>(ret);
+    auto new_gv = module.getOrInsertGlobal(var_name, var_type);
+    if (auto gv = llvm::dyn_cast<llvm::GlobalVariable>(new_gv);
         gv && !gv->hasInitializer()) {
       gv->setInitializer(init_data);
     }
@@ -1101,14 +1101,17 @@ llvm::Constant *GetAddress(const Program &program, llvm::Module &module,
 
       // the address is inside an allocated type
       ret = llvm::dyn_cast<llvm::Constant>(remill::BuildPointerToOffset(
-          builder, ret, ea - start_address, var_ptr_ty));
+          builder, new_gv, ea - start_address, var_ptr_ty));
+
+      DLOG(INFO) << "Built an offset to: " << std::hex << ea << " from: " << start_address
+                << std::dec;
     }
 
   // In C a pointer can be one element beyond an array end.
   // This sometimes results in references to one byte beyond an array end
   // Handle this case, assuming the byte before `ea` exists
   } else if (auto prev_byte = program.FindByte(ea - 1u); ea && prev_byte) {
-
+    LOG(ERROR) << "TODO: Handle case of one past a variable reference";
   } else {
     return nullptr;
   }
@@ -1118,7 +1121,9 @@ llvm::Constant *GetAddress(const Program &program, llvm::Module &module,
     auto &context = module.getContext();
     const auto intptr_ty =
         llvm::Type::getIntNTy(context, dl.getPointerSizeInBits(0));
-    return llvm::ConstantExpr::getPtrToInt(ret, intptr_ty);
+    auto ptr_ret_val = llvm::ConstantExpr::getPtrToInt(ret, intptr_ty);
+    CHECK(ptr_ret_val);
+    return ptr_ret_val;
   }
 
   return nullptr;

--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -983,7 +983,7 @@ void OptimizeModule(const remill::Arch *arch, const Program &program,
 
   LowerTypeOps(program, module);
 
-//  RecoverMemoryReferences(program, module);
+  RecoverMemoryReferences(program, module);
 
   fpm.doInitialization();
   for (auto &func : module) {

--- a/anvill/src/Program.cpp
+++ b/anvill/src/Program.cpp
@@ -115,7 +115,7 @@ class Program::Impl : public std::enable_shared_from_this<Program::Impl> {
 
   std::pair<Byte::Data *, Byte::Meta *> FindByte(uint64_t address);
 
-  std::tuple<Byte::Data *, Byte::Meta *, size_t>
+  std::tuple<Byte::Data *, Byte::Meta *, size_t, uint64_t>
   FindBytesContaining(uint64_t address);
 
   std::tuple<Byte::Data *, Byte::Meta *, size_t> FindBytes(uint64_t address,
@@ -710,7 +710,7 @@ Program::Impl::FindByte(uint64_t address) {
   }
 }
 
-std::tuple<Byte::Data *, Byte::Meta *, size_t>
+std::tuple<Byte::Data *, Byte::Meta *, size_t, uint64_t>
 Program::Impl::FindBytesContaining(uint64_t address) {
   uint64_t limit_address = 0;
   std::vector<Byte::Data> *mapped_data = nullptr;
@@ -720,14 +720,14 @@ Program::Impl::FindBytesContaining(uint64_t address) {
   if (it == bytes.end()) {
     const auto rit = bytes.rbegin();
     if (rit == bytes.rend()) {
-      return {nullptr, nullptr, 0};
+      return {nullptr, nullptr, 0, 0};
 
     } else if (rit->first == address) {
       limit_address = rit->first;
       mapped_data = &(rit->second.first);
       mapped_meta = &(rit->second.second);
     } else {
-      return {nullptr, nullptr, 0};
+      return {nullptr, nullptr, 0, 0};
     }
 
   } else {
@@ -738,9 +738,9 @@ Program::Impl::FindBytesContaining(uint64_t address) {
 
   const auto base_address = limit_address - mapped_data->size();
   if (base_address <= address && address < limit_address) {
-    return {&((*mapped_data)[0]), &((*mapped_meta)[0]), mapped_data->size()};
+    return {&((*mapped_data)[0]), &((*mapped_meta)[0]), mapped_data->size(), base_address};
   } else {
-    return {nullptr, nullptr, 0};
+    return {nullptr, nullptr, 0, 0};
   }
 }
 
@@ -1085,8 +1085,8 @@ Byte Program::FindByte(uint64_t address) const {
 
 // Find which byte sequence (defined in the spec) has the provided `address`
 ByteSequence Program::FindBytesContaining(uint64_t address) const {
-  auto [data, meta, found_size] = impl->FindBytesContaining(address);
-  return ByteSequence(address, data, meta, found_size);
+  auto [data, meta, found_size, base_address] = impl->FindBytesContaining(address);
+  return ByteSequence(base_address, data, meta, found_size);
 }
 
 // Find the next byte.


### PR DESCRIPTION
Temporary fix to ByteSequence such that we know what the real start address of the sequence should be. This is a temporary holdover until we eliminate ByteSequence.

Fix a copypasta bug (we had a local named `ret` and a function-level variable named `ret`) 