### PR TITLE
Fix crash array size, unsupported reg, missing data var

### DIFF
--- a/anvill/python/anvill/type.py
+++ b/anvill/python/anvill/type.py
@@ -197,7 +197,8 @@ class SequentialType(Type):
         self._elem_type = elem_type
 
     def set_num_elements(self, num):
-        assert 0 < num
+        # A variable-length object type can have zero sized array
+        assert 0 <= num
         self._num_elems = num
 
     def size(self, arch):

--- a/anvill/src/Analyze.cpp
+++ b/anvill/src/Analyze.cpp
@@ -896,20 +896,19 @@ static void RecoverStackMemoryAccesses(
         // This thing iteratively builds up a GEP to point to an offset.
         // It moves in increments that are as wide as an element of the
         // indexed type. However if there's some leftover offset, it tries
-        // to do some casting magic to satisfy the request. The assumption
-        // is that the leftover is smaller than the size of a single element
-        // which doesn't hold for tests/binja_none_type.
+        // to do some casting magic to satisfy the request.
         gep = remill::BuildPointerToOffset(
             ir, frame_ptr, goal_offset, llvm::PointerType::get(cell.type, 0));
       }
 
       auto dest_type = cell.use->get()->getType();
+      auto new_val_to_use = gep;
       if (dest_type->isIntegerTy()) {
-        gep = ir.CreatePtrToInt(gep, dest_type);
+        new_val_to_use = ir.CreatePtrToInt(gep, dest_type);
       } else if (dest_type->isPointerTy()) {
-        gep = ir.CreateBitCast(gep, dest_type);
+        new_val_to_use = ir.CreateBitCast(gep, dest_type);
       }
-      cell.use->set(gep);
+      cell.use->set(new_val_to_use);
     }
   }
 }

--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -983,7 +983,7 @@ void OptimizeModule(const remill::Arch *arch, const Program &program,
 
   LowerTypeOps(program, module);
 
-//  RecoverMemoryReferences(program, module);
+  RecoverMemoryReferences(program, module);
 
   fpm.doInitialization();
   for (auto &func : module) {


### PR DESCRIPTION
The PR fixes the binja script crash due to zero-sized array, unsupported x87 status & control regs, and missing data variable for an address. Also, handle named type references as the function parameters. 