### PR TITLE
Internalize `__anvill_reg_*` global variables

### DIFF
--- a/anvill/src/Analyze.cpp
+++ b/anvill/src/Analyze.cpp
@@ -1102,8 +1102,8 @@ llvm::Constant *GetAddress(const Program &program, llvm::Module &module,
       ret = llvm::dyn_cast<llvm::Constant>(remill::BuildPointerToOffset(
           builder, new_gv, ea - start_address, var_ptr_ty));
 
-      DLOG(INFO) << "Built an offset to: " << std::hex << ea << " from: " << start_address
-                << std::dec;
+      DLOG(INFO) << "Built an offset to: " << std::hex << ea
+                 << " from: " << start_address << std::dec;
     }
 
   // In C a pointer can be one element beyond an array end.

--- a/anvill/src/Lift.cpp
+++ b/anvill/src/Lift.cpp
@@ -24,7 +24,6 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Utils.h>
-
 #include <remill/BC/Compat/VectorType.h>
 #include <remill/BC/Util.h>
 
@@ -236,7 +235,7 @@ static void DefineNativeToLiftedWrapper(const remill::Arch *arch,
         auto reg_global = module->getGlobalVariable(reg_name);
         if (!reg_global) {
           reg_global = new llvm::GlobalVariable(
-              *module, reg->type, false, llvm::GlobalValue::ExternalLinkage,
+              *module, reg->type, false, llvm::GlobalValue::InternalLinkage,
               llvm::Constant::getNullValue(reg->type), reg_name);
         }
 
@@ -610,7 +609,7 @@ CreateConstFromMemory(const uint64_t addr, llvm::Type *type,
         initializer_list.push_back(const_elm);
       }
       result = llvm::ConstantVector::get(initializer_list);
-    }break;
+    } break;
 
     default:
       LOG(FATAL) << "Unhandled LLVM Type: " << remill::LLVMThingToString(type);

--- a/anvill/src/MCToIRLifter.cpp
+++ b/anvill/src/MCToIRLifter.cpp
@@ -17,9 +17,8 @@
 
 #include "anvill/MCToIRLifter.h"
 
-#include <glog/logging.h>
 #include <gflags/gflags.h>
-
+#include <glog/logging.h>
 #include <remill/BC/Util.h>
 #include <remill/OS/OS.h>
 
@@ -322,14 +321,14 @@ void MCToIRLifter::InstrumentInstruction(llvm::BasicBlock *block) {
   auto &context = module.getContext();
   if (!log_printf) {
     llvm::Type *args[] = {llvm::Type::getInt8PtrTy(context, 0)};
-    auto fty = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(context), args, true);
+    auto fty =
+        llvm::FunctionType::get(llvm::Type::getVoidTy(context), args, true);
 
     log_printf = llvm::dyn_cast<llvm::Function>(
         module.getOrInsertFunction("printf", fty).getCallee());
 
     std::stringstream ss;
-    arch->ForEachRegister([&] (const remill::Register *reg) {
+    arch->ForEachRegister([&](const remill::Register *reg) {
       if (reg->EnclosingRegister() == reg &&
           reg->type->isIntegerTy(arch->address_size)) {
         ss << reg->name << "=%llx ";
@@ -339,9 +338,9 @@ void MCToIRLifter::InstrumentInstruction(llvm::BasicBlock *block) {
     const auto i32_type = llvm::Type::getInt32Ty(context);
     const auto format_str =
         llvm::ConstantDataArray::getString(context, ss.str(), true);
-    const auto format_var =
-        new llvm::GlobalVariable(module, format_str->getType(), true,
-                                 llvm::GlobalValue::InternalLinkage, format_str);
+    const auto format_var = new llvm::GlobalVariable(
+        module, format_str->getType(), true, llvm::GlobalValue::InternalLinkage,
+        format_str);
 
     llvm::Constant *indices[] = {llvm::ConstantInt::getNullValue(i32_type),
                                  llvm::ConstantInt::getNullValue(i32_type)};
@@ -351,7 +350,7 @@ void MCToIRLifter::InstrumentInstruction(llvm::BasicBlock *block) {
 
   std::vector<llvm::Value *> args;
   args.push_back(log_format_str);
-  arch->ForEachRegister([&] (const remill::Register *reg) {
+  arch->ForEachRegister([&](const remill::Register *reg) {
     if (reg->EnclosingRegister() == reg &&
         reg->type->isIntegerTy(arch->address_size)) {
       args.push_back(inst_lifter.LoadRegValue(block, state_ptr, reg->name));

--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -946,7 +946,7 @@ void OptimizeModule(const remill::Arch *arch, const Program &program,
   RemoveUnusedCalls(module, "__fpclassifyld", changed_funcs);
 
 
-  for (auto changed = true; changed; ) {
+  for (auto changed = true; changed;) {
 
     RemoveUndefMemoryReads(module, "__remill_read_memory_8", changed_funcs);
     RemoveUndefMemoryReads(module, "__remill_read_memory_16", changed_funcs);

--- a/anvill/src/Program.cpp
+++ b/anvill/src/Program.cpp
@@ -738,7 +738,8 @@ Program::Impl::FindBytesContaining(uint64_t address) {
 
   const auto base_address = limit_address - mapped_data->size();
   if (base_address <= address && address < limit_address) {
-    return {&((*mapped_data)[0]), &((*mapped_meta)[0]), mapped_data->size(), base_address};
+    return {&((*mapped_data)[0]), &((*mapped_meta)[0]), mapped_data->size(),
+            base_address};
   } else {
     return {nullptr, nullptr, 0, 0};
   }
@@ -1085,7 +1086,8 @@ Byte Program::FindByte(uint64_t address) const {
 
 // Find which byte sequence (defined in the spec) has the provided `address`
 ByteSequence Program::FindBytesContaining(uint64_t address) const {
-  auto [data, meta, found_size, base_address] = impl->FindBytesContaining(address);
+  auto [data, meta, found_size, base_address] =
+      impl->FindBytesContaining(address);
   return ByteSequence(base_address, data, meta, found_size);
 }
 


### PR DESCRIPTION
Sets internal linkage to `__anvill_reg_*` this enables optimizing them away later on so that they don't pollute the output bitcode.