### PR TITLE
Fix stack overflow due to self pointing refs

### DIFF
--- a/anvill/python/anvill/binja.py
+++ b/anvill/python/anvill/binja.py
@@ -328,8 +328,10 @@ class TypeCache:
         # long double ty may get represented as int80_t. If the size
         # of the IntegerTypeClass is [10, 12], create a float type
         # int32_t (int32_t arg1, int80_t arg2 @ st0)
-        if tinfo.width in [1, 2, 4, 8, 16]:
-            ret = IntegerType(tinfo.width, True)
+        # int24_t type have tinfo width 3. recover it as size 4 byte
+        if tinfo.width in [1, 2, 3, 4, 8, 16]:
+            width = tinfo.width if tinfo.width % 2 == 0 else tinfo.width + 1
+            ret = IntegerType(width, True)
             return ret
         elif tinfo.width in [10, 12]:
             width = tinfo.width

--- a/anvill/src/Lifters/EntityLifter.h
+++ b/anvill/src/Lifters/EntityLifter.h
@@ -58,9 +58,8 @@ class EntityLifterImpl {
   void AddEntity(llvm::Constant *entity, uint64_t address);
 
   // Applies a callback `cb` to each entity at a specified address.
-  void
-  ForEachEntityAtAddress(uint64_t address,
-                         std::function<void(llvm::Constant *)> cb) const;
+  void ForEachEntityAtAddress(uint64_t address,
+                              std::function<void(llvm::Constant *)> cb) const;
 
   // Assuming that `entity` is an entity that was lifted by this `EntityLifter`,
   // then return the address of that entity in the binary being lifted.


### PR DESCRIPTION
Fix stack overflow in the value lifter due to self-pointing references. It also has fixes for handling type `int24_t` recognized by binary ninja. 