### PR TITLE
AArch32 support

### DIFF
--- a/anvill/CMakeLists.txt
+++ b/anvill/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(anvill STATIC
   include/anvill/Type.h
   include/anvill/Result.h
 
+  src/Arch/AArch32_C.cpp
   src/Arch/AArch64_C.cpp
   src/Arch/SPARC32_C.cpp
   src/Arch/SPARC64_C.cpp

--- a/anvill/python/anvill/arch.py
+++ b/anvill/python/anvill/arch.py
@@ -942,6 +942,191 @@ class AArch64Arch(Arch):
     def pointer_size(self):
         return 8
 
+class AArch32Arch(Arch):
+    """AArch32-specific architecture description (ARMv7, 32-bit)."""
+
+    _REG_FAMILY_Rn = lambda l: (("R{}".format(l), 0, 8))
+
+    _REG_FAMILY_qX = lambda l: (
+        ("q{}".format(l), 0, 16),
+        ("d{}".format(l * 2), 0, 8),
+        ("d{}".format(l * 2 + 1), 8, 16),
+        ("s{}".format(l * 4), 0, 4),
+        ("s{}".format(l * 4 + 1), 4, 8),
+        ("s{}".format(l * 4 + 2), 8, 12),
+        ("s{}".format(l * 4 + 3), 12, 16),
+    )
+
+    _REG_FAMILY_q0 = _REG_FAMILY_qX(0)
+    _REG_FAMILY_q1 = _REG_FAMILY_qX(1)
+    _REG_FAMILY_q2 = _REG_FAMILY_qX(2)
+    _REG_FAMILY_q3 = _REG_FAMILY_qX(3)
+    _REG_FAMILY_q4 = _REG_FAMILY_qX(4)
+    _REG_FAMILY_q5 = _REG_FAMILY_qX(5)
+    _REG_FAMILY_q6 = _REG_FAMILY_qX(6)
+    _REG_FAMILY_q7 = _REG_FAMILY_qX(7)
+    _REG_FAMILY_q8 = _REG_FAMILY_qX(8)
+    _REG_FAMILY_q9 = _REG_FAMILY_qX(9)
+    _REG_FAMILY_q10 = _REG_FAMILY_qX(10)
+    _REG_FAMILY_q11 = _REG_FAMILY_qX(11)
+    _REG_FAMILY_q12 = _REG_FAMILY_qX(12)
+    _REG_FAMILY_q13 = _REG_FAMILY_qX(13)
+    _REG_FAMILY_q14 = _REG_FAMILY_qX(14)
+    _REG_FAMILY_q15 = _REG_FAMILY_qX(15)
+
+    _REG_FAMILY_R0 = _REG_FAMILY_Rn(0)
+    _REG_FAMILY_R1 = _REG_FAMILY_Rn(1)
+    _REG_FAMILY_R2 = _REG_FAMILY_Rn(2)
+    _REG_FAMILY_R3 = _REG_FAMILY_Rn(3)
+    _REG_FAMILY_R4 = _REG_FAMILY_Rn(4)
+    _REG_FAMILY_R5 = _REG_FAMILY_Rn(5)
+    _REG_FAMILY_R6 = _REG_FAMILY_Rn(6)
+    _REG_FAMILY_R7 = _REG_FAMILY_Rn(7)
+    _REG_FAMILY_R8 = _REG_FAMILY_Rn(8)
+    _REG_FAMILY_R9 = _REG_FAMILY_Rn(9)
+    _REG_FAMILY_R10 = _REG_FAMILY_Rn(10)
+    _REG_FAMILY_R11 = _REG_FAMILY_Rn(11)
+    _REG_FAMILY_R12 = _REG_FAMILY_Rn(12)
+
+    _REG_FAMILY = {
+        "R0": _REG_FAMILY_R0,
+        "R1": _REG_FAMILY_R1,
+        "R2": _REG_FAMILY_R2,
+        "R3": _REG_FAMILY_R3,
+        "R4": _REG_FAMILY_R4,
+        "R5": _REG_FAMILY_R5,
+        "R6": _REG_FAMILY_R6,
+        "R7": _REG_FAMILY_R7,
+        "R8": _REG_FAMILY_R8,
+        "R9": _REG_FAMILY_R9,
+        "R10": _REG_FAMILY_R10,
+        "R11": _REG_FAMILY_R11,
+        "R12": _REG_FAMILY_R12,
+        "R13": (("SP", 0, 8)),
+        "R14": (("LR", 0, 8)),
+        "R15": (("PC", 0, 8)),
+
+        "SP": (("SP", 0, 8)),
+        "LR": (("LR", 0, 8)),
+        "PC": (("PC", 0, 8)),
+
+        # floating point extension registers only supported with
+        # VFP and SIMD instructions
+        "q0": _REG_FAMILY_q0,
+        "q1": _REG_FAMILY_q1,
+        "q2": _REG_FAMILY_q2,
+        "q3": _REG_FAMILY_q3,
+        "q4": _REG_FAMILY_q4,
+        "q5": _REG_FAMILY_q5,
+        "q6": _REG_FAMILY_q6,
+        "q7": _REG_FAMILY_q7,
+        "q8": _REG_FAMILY_q8,
+        "q9": _REG_FAMILY_q9,
+        "q10": _REG_FAMILY_q10,
+        "q11": _REG_FAMILY_q11,
+        "q12": _REG_FAMILY_q12,
+        "q13": _REG_FAMILY_q13,
+        "q14": _REG_FAMILY_q14,
+        "q15": _REG_FAMILY_q15,
+
+        "d0": _REG_FAMILY_q0,
+        "d1": _REG_FAMILY_q0,
+        "d2": _REG_FAMILY_q1,
+        "d3": _REG_FAMILY_q1,
+        "d4": _REG_FAMILY_q2,
+        "d5": _REG_FAMILY_q2,
+        "d6": _REG_FAMILY_q3,
+        "d7": _REG_FAMILY_q3,
+        "d8": _REG_FAMILY_q4,
+        "d9": _REG_FAMILY_q4,
+        "d10": _REG_FAMILY_q5,
+        "d11": _REG_FAMILY_q5,
+        "d12": _REG_FAMILY_q6,
+        "d13": _REG_FAMILY_q6,
+        "d14": _REG_FAMILY_q7,
+        "d15": _REG_FAMILY_q7,
+
+        "d16": _REG_FAMILY_q8,
+        "d17": _REG_FAMILY_q8,
+        "d18": _REG_FAMILY_q9,
+        "d19": _REG_FAMILY_q9,
+        "d20": _REG_FAMILY_q10,
+        "d21": _REG_FAMILY_q10,
+        "d22": _REG_FAMILY_q11,
+        "d23": _REG_FAMILY_q11,
+        "d24": _REG_FAMILY_q12,
+        "d25": _REG_FAMILY_q12,
+        "d26": _REG_FAMILY_q13,
+        "d27": _REG_FAMILY_q13,
+        "d28": _REG_FAMILY_q14,
+        "d29": _REG_FAMILY_q14,
+        "d30": _REG_FAMILY_q15,
+        "d31": _REG_FAMILY_q15,
+
+        "s0": _REG_FAMILY_q0,
+        "s1": _REG_FAMILY_q0,
+        "s2": _REG_FAMILY_q0,
+        "s3": _REG_FAMILY_q0,
+        "s4": _REG_FAMILY_q1,
+        "s5": _REG_FAMILY_q1,
+        "s6": _REG_FAMILY_q1,
+        "s7": _REG_FAMILY_q1,
+        "s8": _REG_FAMILY_q2,
+        "s9": _REG_FAMILY_q2,
+        "s10": _REG_FAMILY_q2,
+        "s11": _REG_FAMILY_q2,
+        "s12": _REG_FAMILY_q3,
+        "s13": _REG_FAMILY_q3,
+        "s14": _REG_FAMILY_q3,
+        "s15": _REG_FAMILY_q3,
+        "s16": _REG_FAMILY_q4,
+        "s17": _REG_FAMILY_q4,
+        "s18": _REG_FAMILY_q4,
+        "s19": _REG_FAMILY_q4,
+        "s20": _REG_FAMILY_q5,
+        "s21": _REG_FAMILY_q5,
+        "s22": _REG_FAMILY_q5,
+        "s23": _REG_FAMILY_q5,
+        "s24": _REG_FAMILY_q6,
+        "s25": _REG_FAMILY_q6,
+        "s26": _REG_FAMILY_q6,
+        "s27": _REG_FAMILY_q6,
+        "s28": _REG_FAMILY_q7,
+        "s29": _REG_FAMILY_q7,
+        "s30": _REG_FAMILY_q7,
+        "s31": _REG_FAMILY_q7
+    }
+
+    def name(self):
+        return "aarch32"
+
+    def program_counter_name(self):
+        return "PC"
+
+    def stack_pointer_name(self):
+        return "SP"
+
+    def return_address_proto(self):
+        return {"register": "LR", "type": "I"}
+
+    def return_stack_pointer_proto(self, num_bytes_popped):
+        return {"register": "SP", "offset": abs(num_bytes_popped), "type": "I"}
+
+    def pointer_size(self):
+        return 4
+
+    def register_family(self, reg_name):
+        if reg_name.startswith("%"):
+            return self._REG_FAMILY[reg_name[1:].lower()]
+        else:
+            return self._REG_FAMILY[reg_name.lower()]
+
+    def register_name(self, reg_name):
+        if reg_name.startswith("%"):
+            return reg_name[1:].lower()
+        else:
+            return reg_name.lower()
+
 
 class Sparc32Arch(Arch):
     """SPARCv8 architecture description (32-bit)."""

--- a/anvill/python/anvill/ida.py
+++ b/anvill/python/anvill/ida.py
@@ -84,6 +84,8 @@ def _guess_architecture():
     elif "ARM" in inf.procName:
         if inf.is_64bit():
             return "aarch64"
+        elif inf.is_32bit():
+            return "aarch32"
         else:
             raise UnhandledArchitectureType(
                 "Unrecognized 32-bit ARM architecture: {}".format(inf.procName)
@@ -294,6 +296,8 @@ def _get_arch():
         return X86Arch()
     elif name == "aarch64":
         return AArch64Arch()
+    elif name == "aarch32":
+        return AArch32Arch()
     elif name == "sparc32":
         return Sparc32Arch()
     elif name == "sparc64":
@@ -865,6 +869,13 @@ def _get_calling_convention(arch, os, ftd):
             return default_cc, True
         elif (ftd.cc & ida_typeinf.CM_CC_THISCALL) == ida_typeinf.CM_CC_THISCALL:
             return 70, is_variadic
+        else:
+            return default_cc, is_variadic
+
+    elif arch_name == "aarch32":
+        # check for _cdecl calling convention else fallback to default cc
+        if (ftd.cc & ida_typeinf.CM_CC_CDECL) == ida_typeinf.CM_CC_CDECL:
+            return 48, is_variadic
         else:
             return default_cc, is_variadic
 

--- a/anvill/src/Arch/AArch32_C.cpp
+++ b/anvill/src/Arch/AArch32_C.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <anvill/Decl.h>
+#include <glog/logging.h>
+#include <remill/Arch/Arch.h>
+#include <remill/Arch/Name.h>
+
+#include "AllocationState.h"
+#include "Arch.h"
+
+namespace anvill {
+namespace {
+
+static const std::vector<RegisterConstraint> kParamRegConstraints = {
+    RegisterConstraint({VariantConstraint("R0", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R1", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R2", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R3", kTypeIntegral, kMaxBit32)}),
+};
+
+static const std::vector<RegisterConstraint> kReturnRegConstraints = {
+    RegisterConstraint({VariantConstraint("R0", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R1", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R2", kTypeIntegral, kMaxBit32)}),
+    RegisterConstraint({VariantConstraint("R3", kTypeIntegral, kMaxBit32)}),
+};
+
+// Used to split things like `i64`s into multiple `i32`s.
+static llvm::Type *IntegerTypeSplitter(llvm::Type *type) {
+  auto int_ty = llvm::dyn_cast<llvm::IntegerType>(type);
+  if (!int_ty) {
+    return nullptr;
+  }
+
+  auto width = int_ty->getPrimitiveSizeInBits();
+  if (width <= 32) {
+    return nullptr;
+  }
+
+  auto num_elements = (width + 31) / 32;
+  auto i32_ty = llvm::Type::getInt32Ty(type->getContext());
+  return llvm::ArrayType::get(i32_ty, num_elements);
+}
+
+}  // namespace
+
+// This is AAPCS calling convention for armv7 architecture. It does not
+// support AAPCS_VFP calling convention
+// TODO(akshayk) Support AAPCS_VFP calling convention for VFP and advance
+// SIMD support
+class AArch32_C : public CallingConvention {
+ public:
+  explicit AArch32_C(const remill::Arch *arch);
+  virtual ~AArch32_C(void) = default;
+
+  llvm::Error AllocateSignature(FunctionDecl &fdecl,
+                                llvm::Function &func) override;
+
+ private:
+  llvm::Error BindParameters(llvm::Function &function, bool injected_sret,
+                             std::vector<ParameterDecl> &param_decls);
+
+  llvm::Error BindReturnValues(llvm::Function &function, bool &injected_sret,
+                               std::vector<ValueDecl> &ret_decls);
+
+  const std::vector<RegisterConstraint> &parameter_register_constraints;
+  const std::vector<RegisterConstraint> &return_register_constraints;
+};
+
+std::unique_ptr<CallingConvention>
+CallingConvention::CreateAArch32_C(const remill::Arch *arch) {
+  return std::unique_ptr<CallingConvention>(new AArch32_C(arch));
+}
+
+AArch32_C::AArch32_C(const remill::Arch *arch)
+    : CallingConvention(llvm::CallingConv::C, arch),
+      parameter_register_constraints(kParamRegConstraints),
+      return_register_constraints(kReturnRegConstraints) {}
+
+// Allocates the elements of the function signature of func to memory or
+// registers. This includes parameters/arguments, return values, and the return
+// stack pointer.
+llvm::Error AArch32_C::AllocateSignature(FunctionDecl &fdecl,
+                                         llvm::Function &func) {
+
+  // Bind return values first to see if we have injected an sret into the
+  // parameter list. Then, bind the parameters. It is important that we bind the
+  // return values before the parameters in case we inject an sret.
+  bool injected_sret = false;
+  auto err = BindReturnValues(func, injected_sret, fdecl.returns);
+  if (remill::IsError(err)) {
+    return err;
+  }
+
+  err = BindParameters(func, injected_sret, fdecl.params);
+  if (remill::IsError(err)) {
+    return err;
+  }
+
+  fdecl.return_stack_pointer_offset = 0;
+  fdecl.return_stack_pointer = arch->RegisterByName("SP");
+
+  fdecl.return_address.reg = arch->RegisterByName("LR");
+  fdecl.return_address.type = fdecl.return_address.reg->type;
+
+  return llvm::Error::success();
+}
+
+
+llvm::Error
+AArch32_C::BindReturnValues(llvm::Function &function, bool &injected_sret,
+                            std::vector<anvill::ValueDecl> &ret_values) {
+
+  llvm::Type *ret_type = function.getReturnType();
+  injected_sret = false;
+
+  // If there is an sret parameter then it is a special case.
+  if (function.hasStructRetAttr()) {
+    auto &value_declaration = ret_values.emplace_back();
+
+    // Check both first and second parameter because llvm does that in
+    // llvm::Function::hasStructRetAttr()
+    if (function.hasParamAttribute(0, llvm::Attribute::StructRet)) {
+      value_declaration.type =
+          remill::NthArgument(&function, 0)->getType()->getPointerElementType();
+
+    } else if (function.hasParamAttribute(1, llvm::Attribute::StructRet)) {
+      value_declaration.type =
+          remill::NthArgument(&function, 1)->getType()->getPointerElementType();
+    }
+
+    value_declaration.type = llvm::PointerType::get(value_declaration.type, 0);
+
+    if (!ret_type->isVoidTy()) {
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Function '%s' with sret-attributed parameter has non-void return type '%s'",
+          function.getName().str().c_str(),
+          remill::LLVMThingToString(ret_type).c_str());
+    }
+
+    // Indirect return values are passed by pointer through `X8`.
+    value_declaration.reg = arch->RegisterByName("R0");
+    return llvm::Error::success();
+  }
+
+  switch (ret_type->getTypeID()) {
+    case llvm::Type::VoidTyID: return llvm::Error::success();
+
+    case llvm::Type::IntegerTyID: {
+      const auto *int_ty = llvm::dyn_cast<llvm::IntegerType>(ret_type);
+      const auto int32_ty = llvm::Type::getInt32Ty(int_ty->getContext());
+      const auto bit_width = int_ty->getBitWidth();
+      if (bit_width <= 32) {
+        auto &value_declaration = ret_values.emplace_back();
+        value_declaration.reg = arch->RegisterByName("R0");
+        value_declaration.type = ret_type;
+        return llvm::Error::success();
+
+      } else if (bit_width <= 64) {
+        const char *reg_names[] = {"R0", "R1"};
+        for (auto i = 0u; i < 2 && (32 * i) < bit_width; ++i) {
+          auto &value_declaration = ret_values.emplace_back();
+          value_declaration.reg = arch->RegisterByName(reg_names[i]);
+          value_declaration.type = int32_ty;
+        }
+        return llvm::Error::success();
+
+      // Split the integer across `R3:R0`.
+      } else if (bit_width <= 128) {
+        const char *ret_names[] = {"R0", "R1", "R2", "R3"};
+        for (auto i = 0u; i < 4 && (32 * i) < bit_width; ++i) {
+          auto &value_declaration = ret_values.emplace_back();
+          value_declaration.reg = arch->RegisterByName(ret_names[i]);
+          value_declaration.type = int32_ty;
+        }
+        return llvm::Error::success();
+
+      // The integer is too big to split across register;  fall back to
+      // return-value optimization and pass it in R0
+      } else {
+        auto &value_declaration = ret_values.emplace_back();
+        value_declaration.type =
+            llvm::PointerType::get(value_declaration.type, 0);
+        value_declaration.reg = arch->RegisterByName("R0");
+        return llvm::Error::success();
+      }
+    }
+
+    // Pointers always fit into `R0`.
+    case llvm::Type::PointerTyID: {
+      auto &value_declaration = ret_values.emplace_back();
+      value_declaration.reg = arch->RegisterByName("R0");
+      value_declaration.type = ret_type;
+      return llvm::Error::success();
+    }
+
+    case llvm::Type::HalfTyID: {
+      auto &value_declaration = ret_values.emplace_back();
+      value_declaration.reg = arch->RegisterByName("R0");
+      value_declaration.type = ret_type;
+      return llvm::Error::success();
+    }
+
+    case llvm::Type::FloatTyID: {
+      auto &value_declaration = ret_values.emplace_back();
+      value_declaration.reg = arch->RegisterByName("R0");
+      value_declaration.type = ret_type;
+      return llvm::Error::success();
+    }
+
+    case llvm::Type::DoubleTyID: {
+
+      // double types gets split into two integer registers
+      const auto double_ty = llvm::Type::getDoubleTy(ret_type->getContext());
+
+      // get the primitive type size to split them to registers
+      const auto bit_width = double_ty->getScalarSizeInBits();
+      const char *reg_names[] = {"R0", "R1"};
+      for (auto i = 0u; i < 2 && (32 * i) < bit_width; ++i) {
+        auto &value_declaration = ret_values.emplace_back();
+        value_declaration.reg = arch->RegisterByName(reg_names[i]);
+        value_declaration.type = double_ty;
+      }
+      return llvm::Error::success();
+    }
+
+    case llvm::Type::FP128TyID: {
+
+      // double types gets split into two integer registers
+      const auto fp128_ty = llvm::Type::getDoubleTy(ret_type->getContext());
+
+      // get the primitive type size to split them to registers
+      const auto bit_width = fp128_ty->getScalarSizeInBits();
+      const char *reg_names[] = {"R0", "R1", "R2", "R3"};
+      for (auto i = 0u; i < 2 && (32 * i) < bit_width; ++i) {
+        auto &value_declaration = ret_values.emplace_back();
+        value_declaration.reg = arch->RegisterByName(reg_names[i]);
+        value_declaration.type = fp128_ty;
+      }
+      return llvm::Error::success();
+    }
+
+    // Try to split the composite type over registers, and fall back on RO
+    // if it's not possible.
+    case llvm::GetFixedVectorTypeId():
+    case llvm::Type::ArrayTyID:
+    case llvm::Type::StructTyID: {
+      AllocationState alloc_ret(return_register_constraints, arch, this);
+      alloc_ret.config.type_splitter = IntegerTypeSplitter;
+      auto mapping = alloc_ret.TryRegisterAllocate(*ret_type);
+
+      // There is a valid split over registers, so add the mapping
+      if (mapping) {
+        return alloc_ret.CoalescePacking(mapping.getValue(), ret_values);
+
+      } else {
+        auto &value_declaration = ret_values.emplace_back();
+        value_declaration.reg = arch->RegisterByName("R0");
+        value_declaration.type = llvm::PointerType::get(ret_type, 0);
+        return llvm::Error::success();
+      }
+    }
+
+    default: break;
+  }
+
+  return llvm::createStringError(
+      std::errc::invalid_argument,
+      "Could not allocate unsupported type '%s' to return register in function '%s'",
+      remill::LLVMThingToString(ret_type).c_str(),
+      function.getName().str().c_str());
+}
+
+llvm::Error
+AArch32_C::BindParameters(llvm::Function &function, bool injected_sret,
+                          std::vector<ParameterDecl> &parameter_declarations) {
+
+  const auto param_names = TryRecoverParamNames(function);
+  llvm::DataLayout dl(function.getParent());
+
+  // Used to keep track of which registers have been allocated
+  AllocationState alloc_param(parameter_register_constraints, arch, this);
+  alloc_param.config.type_splitter = IntegerTypeSplitter;
+
+  //
+  //  #define X unsigned int
+  //  unsigned a(X a0, X a1, X a2, X a3,
+  //             X a4, X a5, X a6) {
+  //        return a6;
+  //   }
+  //   a:
+  //     ldr     r0, [sp, #4]
+  //     bx      lr
+  //
+  // In the example above argument a5 and a6 gets spilled over the stack
+  // and gets access with the offset. stack offset for armv7 is 0
+
+  unsigned stack_offset = 0;
+  const auto sp_reg = arch->RegisterByName("SP");
+
+  for (auto &argument : function.args()) {
+    const auto &param_name = param_names[argument.getArgNo()];
+    const auto param_type = argument.getType();
+
+    auto allocation = alloc_param.TryRegisterAllocate(*param_type);
+
+    // Try to allocate from a register. If a register is not available then
+    // allocate from the stack.
+    if (allocation) {
+      auto prev_size = parameter_declarations.size();
+
+      for (const auto &param_decl : allocation.getValue()) {
+        auto &declaration = parameter_declarations.emplace_back();
+        declaration.type = param_decl.type;
+        if (param_decl.reg) {
+          declaration.reg = param_decl.reg;
+        } else {
+          declaration.mem_offset = param_decl.mem_offset;
+          declaration.mem_reg = param_decl.mem_reg;
+        }
+      }
+
+      // The parameter fit in one register / stack slot.
+      if ((prev_size + 1u) == parameter_declarations.size()) {
+        if (!param_name.empty()) {
+          parameter_declarations[prev_size].name = param_name;
+        }
+
+      // The parameter was spread across multiple registers.
+      } else if (!param_name.empty()) {
+        for (auto i = 0u; i < (parameter_declarations.size() - prev_size);
+             ++i) {
+          parameter_declarations[prev_size + i].name =
+              param_name + std::to_string(i);
+        }
+      }
+
+    } else {
+      auto &declaration = parameter_declarations.emplace_back();
+      declaration.type = param_type;
+      declaration.mem_offset = static_cast<int64_t>(stack_offset);
+      declaration.mem_reg = sp_reg;
+      stack_offset += dl.getTypeAllocSize(argument.getType());
+
+      if (!param_name.empty()) {
+        declaration.name = param_name;
+      }
+    }
+  }
+
+  return llvm::Error::success();
+}
+
+}  // namespace anvill

--- a/anvill/src/Arch/Arch.cpp
+++ b/anvill/src/Arch/Arch.cpp
@@ -81,6 +81,7 @@ CallingConvention::CreateCCFromArch(const remill::Arch *arch) {
         break;
       }
 
+    case remill::kArchAArch32LittleEndian: return CreateAArch32_C(arch);
     case remill::kArchAArch64LittleEndian: return CreateAArch64_C(arch);
 
     case remill::kArchSparc32:

--- a/anvill/src/Arch/Arch.h
+++ b/anvill/src/Arch/Arch.h
@@ -165,6 +165,9 @@ class CallingConvention {
   CreateX86_64_SysV(const remill::Arch *arch);
 
   static std::unique_ptr<CallingConvention>
+  CreateAArch32_C(const remill::Arch *arch);
+
+  static std::unique_ptr<CallingConvention>
   CreateAArch64_C(const remill::Arch *arch);
 
   static std::unique_ptr<CallingConvention>

--- a/anvill/src/Lifters/DataLifter.cpp
+++ b/anvill/src/Lifters/DataLifter.cpp
@@ -129,7 +129,10 @@ llvm::Constant *DataLifter::GetOrDeclareData(const GlobalVarDecl &decl,
 
     // Fallback to is base is null or offset < 0; bit cast to the
     // correct type
-    const auto ce = llvm::ConstantExpr::getBitCast(found_by_address, type);
+    const auto address_space =
+        found_by_address->getType()->getPointerAddressSpace();
+    const auto ce = llvm::ConstantExpr::getBitCast(
+        found_by_address, type->getPointerTo(address_space));
     lifter_context.AddEntity(ce, decl.address);
     return wrap_with_alias(ce);
   }

--- a/anvill/src/Lifters/ValueLifter.cpp
+++ b/anvill/src/Lifters/ValueLifter.cpp
@@ -276,6 +276,10 @@ llvm::Constant *ValueLifterImpl::GetPointer(uint64_t ea,
   }
 
   alias_ret->setAliasee(ret);
+
+  // NOTE(akshayk): Adding `alias_ret` to entity map may cause type confusion
+  //                on look up. It gets fixed in the data lifter.
+  //
   ent_lifter.AddEntity(alias_ret, ea);
 
   return alias_ret;


### PR DESCRIPTION
Add support for spec recovery from armv7 and thumb2 binaries. The IR generation for thumb2 is not supported yet. Also, need a remill patch to handle pc-relative addressing for armv7 for lifting the test binaries. 