### PR TITLE
fix runtime error in image parser

### DIFF
--- a/anvill/python/anvill/imageparser/__init__.py
+++ b/anvill/python/anvill/imageparser/__init__.py
@@ -18,6 +18,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
 
+from anvill.util import *
+
 
 @dataclass
 class ImageFunctionThunk:

--- a/anvill/python/anvill/imageparser/elfparser.py
+++ b/anvill/python/anvill/imageparser/elfparser.py
@@ -351,7 +351,8 @@ class ELFParser(ImageParser):
 
         dynsym_section_header = self._get_section_header(".dynsym")
         if dynsym_section_header is None:
-            raise RuntimeError("Failed to acquire the '.dynsym' section")
+            DEBUG("WARNING: Failed to acquire the '.dynsym' section")
+            return
 
         is_32_bit = self.get_image_bitness() == 32
 
@@ -387,7 +388,8 @@ class ELFParser(ImageParser):
 
         dynstr_section = self._get_section(".dynstr")
         if dynstr_section is None:
-            raise RuntimeError("Failed to acquire the '.dynstr' section")
+            DEBUG("WARNING: Failed to acquire the '.dynstr' section")
+            return
 
         for section_header in self._section_header_list:
             if section_header.sh_type != SHT_REL and section_header.sh_type != SHT_RELA:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "anvill.binja.bnfunction", "anvill.binja.bnprogram", "anvill.binja.bnvariable",
         "anvill.binja.callingconvention", "anvill.binja.typecache", "anvill.binja.xreftype",
         "anvill.exc", "anvill.function", "anvill.ida.__init__", "anvill.ida.idafunction",
-        "anvill.ida.idaprogram", "anvill.ida.idavariable", "anvill.ida.utils", "anvill.loc",
+        "anvill.ida.idaprogram", "anvill.ida.idavariable", "anvill.ida.utils",
+        "anvill.imageparser.__init__", "anvill.imageparser.elfparser", "anvill.loc",
         "anvill.mem", "anvill.os", "anvill.program", "anvill.type",
         "anvill.var", "anvill.util"])


### PR DESCRIPTION
A binary may not have dynamic symbol table or string table. The changes avoid runtime errors and add a warning log for such cases. 