### PR TITLE
Use cxx-common v0.1.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           - { name: 'ubuntu', tag: '20.04' }
 
         llvm: [ '11' ]
-        cxxcommon_version: [ 'v0.1.3' ]
+        cxxcommon_version: [ 'v0.1.4' ]
 
     runs-on: ubuntu-20.04
     container:
@@ -363,7 +363,7 @@ jobs:
       matrix:
         os: [ 'macos-10.15' ]
         llvm: [ '11' ]
-        cxxcommon_version: [ 'v0.1.3' ]
+        cxxcommon_version: [ 'v0.1.4' ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Fixes for building with latest MacOS 11 development tools