### PR TITLE
cmake: Add option to not touch Python

### DIFF
--- a/anvill/CMakeLists.txt
+++ b/anvill/CMakeLists.txt
@@ -110,7 +110,7 @@ target_public_headers(anvill
   include/anvill/Util.h
 )
 
-if (ANVILL_BUILD_PYTHON3_LIBS)
+if (ANVILL_ENABLE_PYTHON3_LIBS)
   add_subdirectory("python")
 endif()
 

--- a/anvill/CMakeLists.txt
+++ b/anvill/CMakeLists.txt
@@ -110,7 +110,9 @@ target_public_headers(anvill
   include/anvill/Util.h
 )
 
-add_subdirectory("python")
+if (ANVILL_BUILD_PYTHON3_LIBS)
+  add_subdirectory("python")
+endif()
 
 if(ANVILL_ENABLE_TESTS)
   add_subdirectory("tests")

--- a/anvill/python/CMakeLists.txt
+++ b/anvill/python/CMakeLists.txt
@@ -6,7 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-if(ANVILL_ENABLE_INSTALL_TARGET AND NOT ANVILL_INSTALL_PYTHON3_LIBS)
+if(ANVILL_ENABLE_INSTALL_TARGET AND ANVILL_INSTALL_PYTHON3_LIBS)
   install(
     FILES "${PROJECT_SOURCE_DIR}/anvill/plugins/ida/anvill.py"
     DESTINATION "share/anvill/ida"

--- a/anvill/python/CMakeLists.txt
+++ b/anvill/python/CMakeLists.txt
@@ -6,7 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-if(ANVILL_ENABLE_INSTALL_TARGET AND ANVILL_INSTALL_PYTHON3_LIBS)
+if(ANVILL_ENABLE_INSTALL_TARGET AND NOT ANVILL_INSTALL_PYTHON3_LIBS)
   install(
     FILES "${PROJECT_SOURCE_DIR}/anvill/plugins/ida/anvill.py"
     DESTINATION "share/anvill/ida"

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -16,12 +16,11 @@ endif()
 
 set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Build type")
 
-option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components" true)
-option(ANVILL_ENABLE_PYTHON3_LIBS "Build Python 3 libraries" ON)
-option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests" true)
-cmake_dependent_option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" OFF
-  "NOT ANVILL_ENABLE_PYTHON3_LIBS OR NOT ANVILL_ENABLE_INSTALL_TARGET" OFF
-  )
+option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components" TRUE)
+option(ANVILL_ENABLE_PYTHON3_LIBS "Build Python 3 libraries" TRUE)
+cmake_dependent_option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" FALSE
+  "ANVILL_ENABLE_PYTHON3_LIBS" FALSE)
+option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests" TRUE)
 option(ANVILL_ENABLE_SANITIZERS "Set to ON to enable sanitizers. May not work with VCPKG")
 
 set(VCPKG_ROOT "" CACHE FILEPATH "Root directory to use for vcpkg-managed dependencies")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -15,8 +15,11 @@ endif()
 set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Build type")
 
 option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components" true)
+option(ANVILL_BUILD_PYTHON3_LIBS "Build Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" ON)
+if(ANVILL_BUILD_PYTHON3_LIBS AND ANVILL_ENABLE_INSTALL_TARGET)
+  option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" ON)
+endif()
 option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests" true)
-option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging")
 option(ANVILL_ENABLE_SANITIZERS "Set to ON to enable sanitizers. May not work with VCPKG")
 
 set(VCPKG_ROOT "" CACHE FILEPATH "Root directory to use for vcpkg-managed dependencies")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -6,6 +6,8 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
+include(CMakeDependentOption)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(default_build_type "Release")
 else()
@@ -15,11 +17,11 @@ endif()
 set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Build type")
 
 option(ANVILL_ENABLE_INSTALL_TARGET "Set to ON to enable the install directives. This installs both the native and python components" true)
-option(ANVILL_BUILD_PYTHON3_LIBS "Build Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" ON)
-if(ANVILL_BUILD_PYTHON3_LIBS AND ANVILL_ENABLE_INSTALL_TARGET)
-  option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" ON)
-endif()
+option(ANVILL_ENABLE_PYTHON3_LIBS "Build Python 3 libraries" ON)
 option(ANVILL_ENABLE_TESTS "Set to ON to enable the tests" true)
+cmake_dependent_option(ANVILL_INSTALL_PYTHON3_LIBS "Install Python 3 libraries to the **local machine** at build time. Mostly used for local development, not required for packaging" OFF
+  "NOT ANVILL_ENABLE_PYTHON3_LIBS OR NOT ANVILL_ENABLE_INSTALL_TARGET" OFF
+  )
 option(ANVILL_ENABLE_SANITIZERS "Set to ON to enable sanitizers. May not work with VCPKG")
 
 set(VCPKG_ROOT "" CACHE FILEPATH "Root directory to use for vcpkg-managed dependencies")


### PR DESCRIPTION
This is generally useful if someone doesn't want to worry about the Python setup, and I also use it in cxx-common.

(commit messages aren't the most accurate, just look at the diff 🙂 )