### PR TITLE
Anvill xor converter pass

### DIFF
--- a/libraries/anvill_passes/CMakeLists.txt
+++ b/libraries/anvill_passes/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(anvill_passes STATIC
   src/TransformationErrorManager.h
   src/TransformationErrorManager.cpp
   src/TransformRemillJumpIntrinsics.cpp
+
+  src/ConvertXorToCmp.cpp
 )
 
 target_include_directories(anvill_passes PUBLIC

--- a/libraries/anvill_passes/include/anvill/Transforms.h
+++ b/libraries/anvill_passes/include/anvill/Transforms.h
@@ -106,8 +106,7 @@ llvm::FunctionPass *CreateRemoveUnusedFPClassificationCalls(void);
 llvm::FunctionPass *CreateLowerRemillMemoryAccessIntrinsics(void);
 
 // Type information from prior lifting efforts, or from front-end tools
-// (e.g. Binary Ninja) is plumbed through the system by way of calls to
-// intrinsic functions such as `__anvill_type<blah>`. These function calls
+// (e.g. Binary Ninja) is plumbed through the system by way of calls to // intrinsic functions such as `__anvill_type<blah>`. These function calls
 // don't interfere (too much) with optimizations, and they also survive
 // optimizations. In general, the key role that they serve is to enable us to
 // propagate through pointer type information at an instruction/register
@@ -239,5 +238,21 @@ llvm::FunctionPass *CreateRemoveTrivialPhisAndSelects(void);
 // `RemoveRemillFunctionReturns` transform
 llvm::FunctionPass *
 CreateTransformRemillJumpIntrinsics(const EntityLifter &lifter);
+
+// Finds values in the form of:
+// %cmp = icmp eq val1, val2
+// %n = xor %cmp, 1
+// (optional):
+// %br %cmp, d1, d2
+// and converts it to :
+// %cmp = icmp ne val1, val2
+// %n = %cmp
+// %br %cmp, d2, d1
+//
+// This happens often enough in lifted code due to bit shift ops, and the code
+// with xors is more difficult to analyze and for a human to read
+// This pass should only work on boolean values, and handle when those are used
+// in Branches and Selects
+llvm::FunctionPass *CreateConvertXorToCmp(void);
 
 }  // namespace anvill

--- a/libraries/anvill_passes/src/ConvertXorToCmp.cpp
+++ b/libraries/anvill_passes/src/ConvertXorToCmp.cpp
@@ -89,11 +89,9 @@ bool ConvertXorToCmp::runOnFunction(llvm::Function &func) {
         if (lhs_c && lhs_c->getType()->getBitWidth() == 1 &&
             lhs_c->isAllOnesValue() && rhs_cmp) {
           xors.emplace_back(binop);
-        }
-
-        // right side is a constant int 1 (true), left side is a cmp
-        if (rhs_c && rhs_c->getType()->getBitWidth() == 1 &&
+        } else if (rhs_c && rhs_c->getType()->getBitWidth() == 1 &&
             rhs_c->isAllOnesValue() && lhs_cmp) {
+          // right side is a constant int 1 (true), left side is a cmp
           xors.emplace_back(binop);
         }
       }

--- a/libraries/anvill_passes/src/ConvertXorToCmp.cpp
+++ b/libraries/anvill_passes/src/ConvertXorToCmp.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <anvill/ABI.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Pass.h>
+#include <glog/logging.h>
+#include <vector>
+
+namespace anvill {
+namespace {
+
+class ConvertXorToCmp final : public llvm::FunctionPass {
+ public:
+  ConvertXorToCmp(void)
+      : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &func) override;
+
+ private:
+  static char ID;
+};
+
+char ConvertXorToCmp::ID = '\0';
+
+// Get which operand for a binary operator is an ICmpInst
+// nullptr if neither
+static llvm::ICmpInst* getComparisonOperand(llvm::BinaryOperator *op) {
+  auto rhs_cmp = llvm::dyn_cast<llvm::ICmpInst>(op->getOperand(1));
+  if(rhs_cmp) {
+    return rhs_cmp;
+  }
+
+  auto lhs_cmp = llvm::dyn_cast<llvm::ICmpInst>(op->getOperand(0));
+  if(lhs_cmp) {
+    return lhs_cmp;
+  }
+
+  return nullptr;
+}
+
+// from the LLVM documentation, we should handle the following comparisons
+//ICMP_EQ 	equal
+//ICMP_NE 	not equal
+//ICMP_UGT 	unsigned greater than
+//ICMP_UGE 	unsigned greater or equal
+//ICMP_ULT 	unsigned less than
+//ICMP_ULE 	unsigned less or equal
+//ICMP_SGT 	signed greater than
+//ICMP_SGE 	signed greater or equal
+//ICMP_SLT 	signed less than
+//ICMP_SLE 	signed less or equal
+static llvm::Value* negateCmpPredicate(llvm::ICmpInst *cmp) {
+  auto pred = cmp->getPredicate();
+  llvm::IRBuilder<> ir(cmp);
+  llvm::ICmpInst::Predicate new_pred = pred;
+
+  switch(pred) {
+    // equality
+    case llvm::ICmpInst::ICMP_EQ:
+      new_pred = llvm::ICmpInst::ICMP_NE;
+      break;
+    case llvm::ICmpInst::ICMP_NE:
+      new_pred = llvm::ICmpInst::ICMP_EQ;
+      break;
+
+    // unsigned compares
+    case llvm::ICmpInst::ICMP_UGT:
+      new_pred = llvm::ICmpInst::ICMP_ULE;
+      break;
+    case llvm::ICmpInst::ICMP_UGE:
+      new_pred = llvm::ICmpInst::ICMP_ULT;
+      break;
+    case llvm::ICmpInst::ICMP_ULT:
+      new_pred = llvm::ICmpInst::ICMP_UGE;
+      break;
+    case llvm::ICmpInst::ICMP_ULE:
+      new_pred = llvm::ICmpInst::ICMP_UGT;
+      break;
+
+    // signed compares
+    case llvm::ICmpInst::ICMP_SGT:
+      new_pred = llvm::ICmpInst::ICMP_SLE;
+      break;
+    case llvm::ICmpInst::ICMP_SGE:
+      new_pred = llvm::ICmpInst::ICMP_SLT;
+      break;
+    case llvm::ICmpInst::ICMP_SLT:
+      new_pred = llvm::ICmpInst::ICMP_SGE;
+      break;
+    case llvm::ICmpInst::ICMP_SLE:
+      new_pred = llvm::ICmpInst::ICMP_SGT;
+      break;
+
+    default:
+      // something we don't know; abort mission
+      DLOG(ERROR) << "Error: encountered and unknown predicate type!";
+      return nullptr;
+  }
+
+  // create a new compare with negated predicate
+  return ir.CreateICmp(new_pred, cmp->getOperand(0), cmp->getOperand(1));
+}
+
+bool ConvertXorToCmp::runOnFunction(llvm::Function &func) {
+  std::vector<llvm::BinaryOperator *> xors;
+
+  for (auto &inst : llvm::instructions(func)) {
+    // check for binary op
+    if (auto binop = llvm::dyn_cast<llvm::BinaryOperator>(&inst)) {
+      // binary op is a xor
+      if (binop->getOpcode() == llvm::Instruction::Xor) {
+        // xor has a constant as either lhs or rhs, and its a one-bit constant of size 1
+        auto lhs_c = llvm::dyn_cast<llvm::ConstantInt>(binop->getOperand(0));
+        auto lhs_cmp = llvm::dyn_cast<llvm::ICmpInst>(binop->getOperand(0));
+
+        auto rhs_c = llvm::dyn_cast<llvm::ConstantInt>(binop->getOperand(1));
+        auto rhs_cmp = llvm::dyn_cast<llvm::ICmpInst>(binop->getOperand(1));
+
+
+        // left side is a constant int 1 (true), right side is a cmpinst
+        if (lhs_c && lhs_c->getType()->getBitWidth() == 1 &&
+            lhs_c->getValue() == 1 && rhs_cmp) {
+          xors.emplace_back(binop);
+        }
+
+        // right side is a constant int 1 (true), left side is a cmp
+        if (rhs_c && rhs_c->getType()->getBitWidth() == 1 &&
+            rhs_c->getValue() == 1 && lhs_cmp) {
+          xors.emplace_back(binop);
+        }
+      }
+    }
+  }
+
+  auto changed = false;
+  int replaced_items = 0;
+
+  for (auto xori : xors) {
+    // find predicate from xor's operands
+    auto cmp = getComparisonOperand(xori);
+    if(! cmp) {
+      DLOG(ERROR) << "Error: Xor should have a comparison operand, but we can't find it again";
+      continue;
+    }
+    // negate predicate
+    auto neg_cmp = negateCmpPredicate(cmp);
+    if(neg_cmp) {
+      replaced_items += 1;
+
+      // replace uses of predicate with negated predicate
+      cmp->replaceAllUsesWith(neg_cmp);
+      // delete original predicate
+      cmp->eraseFromParent();
+
+      // replace uses of xor with negated predicate
+      xori->replaceAllUsesWith(neg_cmp);
+      // delte xor
+      xori->eraseFromParent();
+      changed = true;
+    }
+  }
+
+  LOG(INFO) << "ConvertXorToCmp: replaced " << replaced_items << " xors with negated comparisons";
+  return changed;
+}
+
+}  // namespace
+
+// Convert operations in the form of:
+// (left OP right) ^ 1
+// into:
+// (left !OP right)
+// this makes the output more natural for humans and computers to reason about
+// This problem comes up a fair bit due to how some instruction semantics compute carry/parity/etc bits
+llvm::FunctionPass *CreateConvertXorToCmp(void) {
+  return new ConvertXorToCmp;
+}
+
+}  // namespace anvill

--- a/libraries/anvill_passes/tests/CMakeLists.txt
+++ b/libraries/anvill_passes/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ add_executable(test_anvill_passes
   src/InstructionFolderPass.cpp
   src/BrightenPointers.cpp
   src/TransformRemillJump.cpp
+
+  src/XorConversionPass.cpp
 )
 
 target_link_libraries(test_anvill_passes PRIVATE

--- a/libraries/anvill_passes/tests/data/xor_conversion.ll
+++ b/libraries/anvill_passes/tests/data/xor_conversion.ll
@@ -1,0 +1,58 @@
+; ModuleID = 'xor_conv_1.c'
+source_filename = "xor_conv_1.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@.str = private unnamed_addr constant [13 x i8] c"f == false/0\00", align 1
+@.str.1 = private unnamed_addr constant [12 x i8] c"f == true/1\00", align 1
+@.str.2 = private unnamed_addr constant [47 x i8] c"this is a more complex branch for f == false/0\00", align 1
+@.str.3 = private unnamed_addr constant [46 x i8] c"this is a more complex branch for f == true/1\00", align 1
+
+; Function Attrs: nofree nounwind uwtable
+define dso_local void @xor_as_not(i8* nocapture readonly %0, i8* nocapture %1) local_unnamed_addr #0 {
+  %3 = getelementptr inbounds i8, i8* %0, i64 4
+  %4 = load i8, i8* %3, align 1, !tbaa !2
+  %5 = and i8 %4, 12
+  %6 = icmp eq i8 %5, 0
+  %7 = xor i1 %6, true
+  %8 = zext i1 %7 to i8
+  %9 = getelementptr inbounds i8, i8* %1, i64 5
+  store i8 %8, i8* %9, align 1, !tbaa !2
+  %10 = select i1 %6, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @.str.1, i64 0, i64 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0)
+  %11 = call i32 @puts(i8* nonnull dereferenceable(1) %10)
+  store i8 %8, i8* %9, align 1, !tbaa !2
+  br i1 %6, label %18, label %12
+
+12:                                               ; preds = %2
+  %13 = call i32 @puts(i8* nonnull dereferenceable(1) getelementptr inbounds ([47 x i8], [47 x i8]* @.str.2, i64 0, i64 0))
+  %14 = getelementptr inbounds i8, i8* %0, i64 12
+  %15 = load i8, i8* %14, align 1, !tbaa !2
+  %16 = load i8, i8* %3, align 1, !tbaa !2
+  %17 = sub i8 %15, %16
+  store i8 %17, i8* %1, align 1, !tbaa !2
+  br label %21
+
+18:                                               ; preds = %2
+  %19 = call i32 @puts(i8* nonnull dereferenceable(1) getelementptr inbounds ([46 x i8], [46 x i8]* @.str.3, i64 0, i64 0))
+  %20 = getelementptr inbounds i8, i8* %1, i64 1
+  store i8 0, i8* %20, align 1, !tbaa !2
+  br label %21
+
+21:                                               ; preds = %18, %12
+  ret void
+}
+
+; Function Attrs: nofree nounwind
+declare dso_local i32 @puts(i8* nocapture readonly) local_unnamed_addr #1
+
+attributes #0 = { nofree nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nofree nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"Debian clang version 11.1.0-++20210428103904+1fdec59bffc1-1~exp1~20210428204532.8"}
+!2 = !{!3, !3, i64 0}
+!3 = !{!"omnipotent char", !4, i64 0}
+!4 = !{!"Simple C/C++ TBAA"}

--- a/libraries/anvill_passes/tests/data/xor_conversion_nochange.ll
+++ b/libraries/anvill_passes/tests/data/xor_conversion_nochange.ll
@@ -1,0 +1,38 @@
+; ModuleID = 'xor_conv_2.c'
+source_filename = "xor_conv_2.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+; Function Attrs: nofree norecurse nounwind uwtable
+define dso_local void @xor_as_not_nochange(i8* nocapture readonly %0, i8* nocapture %1) local_unnamed_addr #0 {
+  %3 = getelementptr inbounds i8, i8* %0, i64 4
+  %4 = load i8, i8* %3, align 1, !tbaa !2
+  %5 = and i8 %4, 12
+  %6 = icmp eq i8 %5, 0
+  %7 = zext i1 %6 to i8
+  %8 = xor i1 %6, true
+  %9 = zext i1 %8 to i8
+  %10 = getelementptr inbounds i8, i8* %1, i64 5
+  store i8 %9, i8* %10, align 1, !tbaa !2
+  %11 = getelementptr inbounds i8, i8* %1, i64 1
+  store i8 %7, i8* %11, align 1, !tbaa !2
+  %12 = zext i1 %6 to i64
+  %13 = getelementptr inbounds i8, i8* %0, i64 %12
+  %14 = load i8, i8* %13, align 1, !tbaa !2
+  %15 = add i8 %14, 1
+  store i8 %15, i8* %1, align 1, !tbaa !2
+  %16 = getelementptr inbounds i8, i8* %1, i64 3
+  store i8 %9, i8* %16, align 1, !tbaa !2
+  ret void
+}
+
+attributes #0 = { nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"Debian clang version 11.1.0-++20210428103904+1fdec59bffc1-1~exp1~20210428204532.8"}
+!2 = !{!3, !3, i64 0}
+!3 = !{!"omnipotent char", !4, i64 0}
+!4 = !{!"Simple C/C++ TBAA"}

--- a/libraries/anvill_passes/tests/src/XorConversionPass.cpp
+++ b/libraries/anvill_passes/tests/src/XorConversionPass.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <anvill/Lifters/EntityLifter.h>
+#include <anvill/Transforms.h>
+#include <doctest.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Verifier.h>
+#include <remill/Arch/Arch.h>
+#include <remill/Arch/Name.h>
+#include <remill/OS/OS.h>
+
+#include <iostream>
+
+#include "Utils.h"
+
+namespace anvill {
+
+TEST_SUITE("XorConversion") {
+  TEST_CASE("Convert a Xor used in a BranchInst and SelectInst") {
+    llvm::LLVMContext llvm_context;
+    auto module = LoadTestData(llvm_context, "xor_conversion.ll");
+
+    auto arch = remill::Arch::Build(&llvm_context, remill::GetOSName("linux"),
+                                    remill::GetArchName("amd64"));
+    REQUIRE(arch != nullptr);
+
+    anvill::LifterOptions options(arch.get(), *module.get(), nullptr);
+
+    // memory and types will not get used and create lifter with null
+    anvill::EntityLifter lifter(options, nullptr, nullptr);
+
+    CHECK(RunFunctionPass(module.get(), CreateConvertXorToCmp()));
+
+    const auto xor_as_not = module->getFunction("xor_as_not");
+    int xor_count = 0;
+    for (auto &inst : llvm::instructions(xor_as_not)) {
+      if (auto binop = llvm::dyn_cast<llvm::BinaryOperator>(&inst)) {
+
+        // binary op is a xor
+        if (binop->getOpcode() == llvm::Instruction::Xor) {
+          xor_count += 1;
+        }
+      }
+    }
+
+    REQUIRE(xor_as_not);
+    REQUIRE(xor_count == 0);
+  }
+
+  TEST_CASE("DO NOT convert a xor used as a branch/select") {
+    llvm::LLVMContext llvm_context;
+    auto module = LoadTestData(llvm_context, "xor_conversion_nochange.ll");
+
+    auto arch = remill::Arch::Build(&llvm_context, remill::GetOSName("linux"),
+                                    remill::GetArchName("amd64"));
+    REQUIRE(arch != nullptr);
+
+    anvill::LifterOptions options(arch.get(), *module.get(), nullptr);
+
+    // memory and types will not get used and create lifter with null
+    anvill::EntityLifter lifter(options, nullptr, nullptr);
+
+    CHECK(RunFunctionPass(module.get(), CreateConvertXorToCmp()));
+
+    const auto xor_as_not_nochange = module->getFunction("xor_as_not_nochange");
+    int xor_count = 0;
+    for (auto &inst : llvm::instructions(xor_as_not_nochange)) {
+      if (auto binop = llvm::dyn_cast<llvm::BinaryOperator>(&inst)) {
+
+        // binary op is a xor
+        if (binop->getOpcode() == llvm::Instruction::Xor) {
+          xor_count += 1;
+        }
+      }
+    }
+
+    REQUIRE(xor_as_not_nochange);
+    REQUIRE(xor_count == 1);
+  }
+}
+
+
+}  // namespace anvill


### PR DESCRIPTION
Convert some specific instances of the form:

```
%c = icmp pred, op1, op2
%x = xor i1 %c , true
```
into:
```
%c = icmp !pred, op1, op2
%x = %c
```

And update uses of BranchInst and SelectInst. Bail out if uses include things that are not branches or selects.

This comes up often enough in lifted bitcode to do this transform.