### PR TITLE
Stack offset error

### DIFF
--- a/anvill/include/anvill/Analysis/CrossReferenceResolver.h
+++ b/anvill/include/anvill/Analysis/CrossReferenceResolver.h
@@ -58,6 +58,9 @@ struct ResolvedCrossReference {
   // operands being hinted, we drop the type hints.
   llvm::Type *hinted_value_type{nullptr};
 
+  // size of the operand that is used to adjust the displacement of references
+  unsigned size{0};
+
   // If we have a `hinted_type`, then how "far away" are we from that hinted
   // type? I.e. we might be doing a `getelementptr` on a pointer that is type
   // hinted, and so this represents the displacement induced by the GEP indices.
@@ -95,8 +98,8 @@ struct ResolvedCrossReference {
     return is_valid;
   }
 
-  // Returns the displacement value, adjusted according to pointer size
-  std::int64_t Displacement(const llvm::DataLayout &dl) const;
+  // Returns the displacement value, adjusted according to operand size
+  std::int64_t Displacement(void) const;
 };
 
 // Attempts to fold cross-references down into their intended addresses. This

--- a/anvill/python/anvill/binja/typecache.py
+++ b/anvill/python/anvill/binja/typecache.py
@@ -62,7 +62,12 @@ class TypeCache:
         )
 
         ret = StructureType()
-        self._cache[self._cache_key(tinfo)] = ret
+
+        # If struct has no registered name, don't put it in the cache. It
+        # is anonymous struct and can cause cache collision
+        if tinfo.registered_name:
+            self._cache[self._cache_key(tinfo)] = ret
+
         for elem in tinfo.structure.members:
             ret.add_element_type(self._convert_bn_type(elem.type))
 
@@ -74,7 +79,11 @@ class TypeCache:
         assert tinfo.structure.type == bn.StructureType.UnionStructureType
 
         ret = UnionType()
-        self._cache[self._cache_key(tinfo)] = ret
+
+        # If union has no registered name, don't put it in the cache. It
+        # is anonymous union and can cause cache collision
+        if tinfo.registered_name:
+            self._cache[self._cache_key(tinfo)] = ret
         for elem in tinfo.structure.members:
             ret.add_element_type(self._convert_bn_type(elem.type))
 
@@ -86,7 +95,12 @@ class TypeCache:
         assert tinfo.type_class == bn.TypeClass.EnumerationTypeClass
 
         ret = EnumType()
-        self._cache[self._cache_key(tinfo)] = ret
+
+        # If enum has no registered name, don't put it in the cache. It
+        # is anonymous enum and can cause cache collision with other
+        # anonymous enum
+        if tinfo.registered_name:
+            self._cache[self._cache_key(tinfo)] = ret
         # The underlying type of enum will be an Interger of size info.width
         ret.set_underlying_type(IntegerType(tinfo.width, False))
         return ret

--- a/libraries/anvill_passes/src/BrightenPointerOperations.cpp
+++ b/libraries/anvill_passes/src/BrightenPointerOperations.cpp
@@ -593,7 +593,6 @@ PointerLifter::visitPHINode(llvm::PHINode &inst) {
   for (auto i = 0u; i < num_vals; i++) {
     auto incoming_val = inst.getIncomingValue(i);
     auto incoming_block = inst.getIncomingBlock(i);
-    llvm::IRBuilder<> sub_ir(incoming_block->getTerminator()->getPrevNode());
     if (auto val_inst = llvm::dyn_cast<llvm::Instruction>(incoming_val)) {
 
       // Visit possible reference
@@ -789,7 +788,7 @@ PointerLifter::visitBinaryOperator(llvm::BinaryOperator &binop) {
         llvm::IRBuilder<> ir(inst);
         llvm::Value *indexed_pointer =
             GetIndexedPointer(ir, rhs_ptr->getOperand(0), lhs_const,
-                              lhs_ptr->getOperand(0)->getType());
+                              rhs_ptr->getOperand(0)->getType());
         llvm::Value *int_cast =
             ir.CreateBitOrPointerCast(indexed_pointer, inst->getType());
         ReplaceAllUses(inst, int_cast);

--- a/libraries/anvill_passes/src/RecoverStackFrameInformation.cpp
+++ b/libraries/anvill_passes/src/RecoverStackFrameInformation.cpp
@@ -154,7 +154,7 @@ RecoverStackFrameInformation::AnalyzeStackFrame(llvm::Function &function) {
     }
 
     // The offset from the stack pointer.
-    const auto stack_offset = reference.Displacement(data_layout);
+    const auto stack_offset = reference.Displacement();
 
     // Update the boundaries, based on the offset we have found
     std::uint64_t type_size = data_layout.getTypeAllocSize(


### PR DESCRIPTION
The stack offset was not getting sign-extended while resolving stack frame references. Fix the error due to the stripping up of the reference address. 