### PR TITLE
Propagate instruction metadata in passes

### DIFF
--- a/libraries/anvill_passes/src/BrightenPointerOperations.cpp
+++ b/libraries/anvill_passes/src/BrightenPointerOperations.cpp
@@ -224,7 +224,6 @@ void PointerLifter::ReplaceAllUses(llvm::Value *old_val, llvm::Value *new_val) {
     to_remove.insert(old_inst);
     rep_map[old_inst] = new_val;
     made_progress = true;
-    // Transfer metadata from replaced instruction.
     CopyMetadataTo(old_val, new_val);
   } else {
     LOG(ERROR) << "Cannot replace " << remill::LLVMThingToString(old_val)

--- a/libraries/anvill_passes/src/BrightenPointerOperations.cpp
+++ b/libraries/anvill_passes/src/BrightenPointerOperations.cpp
@@ -224,6 +224,10 @@ void PointerLifter::ReplaceAllUses(llvm::Value *old_val, llvm::Value *new_val) {
     to_remove.insert(old_inst);
     rep_map[old_inst] = new_val;
     made_progress = true;
+    // Transfer metadata from replaced instruction.
+    auto *new_inst = llvm::dyn_cast<llvm::Instruction>(new_val);
+    CHECK(new_inst);
+    new_inst->copyMetadata(*old_inst);
   } else {
     LOG(ERROR) << "Cannot replace " << remill::LLVMThingToString(old_val)
                << " with " << remill::LLVMThingToString(new_val) << " in "
@@ -373,6 +377,10 @@ llvm::Value *PointerLifter::flattenGEP(llvm::GetElementPtrInst *gep) {
   } else {
     flat_gep = ir.CreateGEP(gep->getType(), base_gep, last_index);
   }
+  // Transfer metadata to flattened GEP.
+  auto *flat_gep_inst = llvm::dyn_cast<llvm::Instruction>(flat_gep);
+  CHECK(flat_gep_inst);
+  flat_gep_inst->copyMetadata(*gep);
   return flat_gep;
 }
 

--- a/libraries/anvill_passes/src/BrightenPointerOperations.cpp
+++ b/libraries/anvill_passes/src/BrightenPointerOperations.cpp
@@ -225,9 +225,9 @@ void PointerLifter::ReplaceAllUses(llvm::Value *old_val, llvm::Value *new_val) {
     rep_map[old_inst] = new_val;
     made_progress = true;
     // Transfer metadata from replaced instruction.
-    auto *new_inst = llvm::dyn_cast<llvm::Instruction>(new_val);
-    CHECK(new_inst);
-    new_inst->copyMetadata(*old_inst);
+    if (auto *new_inst = llvm::dyn_cast<llvm::Instruction>(new_val)) {
+      new_inst->copyMetadata(*old_inst);
+    }
   } else {
     LOG(ERROR) << "Cannot replace " << remill::LLVMThingToString(old_val)
                << " with " << remill::LLVMThingToString(new_val) << " in "

--- a/libraries/anvill_passes/src/BrightenPointerOperations.cpp
+++ b/libraries/anvill_passes/src/BrightenPointerOperations.cpp
@@ -1071,7 +1071,7 @@ void PointerLifter::LiftFunction(llvm::Function &func) {
         // DLOG(ERROR) << "Replacing:\n";
         // DLOG(ERROR) << remill::LLVMThingToString(inst) << "\n";
         // DLOG(ERROR) << remill::LLVMThingToString(rep_inst) << "\n";
-        CopyMetadataTo(rep_inst, inst);
+        CopyMetadataTo(inst, rep_inst);
         inst->replaceAllUsesWith(rep_inst);
       } else {
         DLOG(ERROR) << "Can't replace these two:\n";

--- a/libraries/anvill_passes/src/ConvertXorToCmp.cpp
+++ b/libraries/anvill_passes/src/ConvertXorToCmp.cpp
@@ -196,6 +196,9 @@ bool ConvertXorToCmp::runOnFunction(llvm::Function &func) {
     // negate predicate
     auto neg_cmp = negateCmpPredicate(cmp);
     if (neg_cmp) {
+      auto *neg_cmp_inst = llvm::dyn_cast<llvm::Instruction>(neg_cmp);
+      CHECK(neg_cmp_inst);
+      neg_cmp_inst->copyMetadata(*xori);
       replaced_items += 1;
 
       // invert all branches

--- a/libraries/anvill_passes/src/ConvertXorToCmp.cpp
+++ b/libraries/anvill_passes/src/ConvertXorToCmp.cpp
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Utils.h"
+
 #include <anvill/ABI.h>
 #include <glog/logging.h>
 #include <llvm/IR/Constants.h>
@@ -27,8 +29,6 @@
 #include <optional>
 #include <tuple>
 #include <vector>
-
-#include "Utils.h"
 
 namespace anvill {
 namespace {

--- a/libraries/anvill_passes/src/ConvertXorToCmp.cpp
+++ b/libraries/anvill_passes/src/ConvertXorToCmp.cpp
@@ -28,6 +28,8 @@
 #include <tuple>
 #include <vector>
 
+#include "Utils.h"
+
 namespace anvill {
 namespace {
 
@@ -196,9 +198,7 @@ bool ConvertXorToCmp::runOnFunction(llvm::Function &func) {
     // negate predicate
     auto neg_cmp = negateCmpPredicate(cmp);
     if (neg_cmp) {
-      auto *neg_cmp_inst = llvm::dyn_cast<llvm::Instruction>(neg_cmp);
-      CHECK(neg_cmp_inst);
-      neg_cmp_inst->copyMetadata(*xori);
+      CopyMetadataTo(xori, neg_cmp);
       replaced_items += 1;
 
       // invert all branches

--- a/libraries/anvill_passes/src/InstructionFolderPass.cpp
+++ b/libraries/anvill_passes/src/InstructionFolderPass.cpp
@@ -506,10 +506,6 @@ bool InstructionFolderPass::FoldPHINodeWithBinaryOp(
     IncomingValue new_incoming_value;
     new_incoming_value.value =
         builder.CreateBinOp(opcode, incoming_value.value, operand);
-    auto *new_incoming_ins =
-        llvm::dyn_cast<llvm::Instruction>(new_incoming_value.value);
-    CHECK(new_incoming_ins);
-    new_incoming_ins->copyMetadata(*binary_op_instr);
 
     new_incoming_value.basic_block = incoming_value.basic_block;
     new_incoming_values.push_back(std::move(new_incoming_value));

--- a/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
@@ -50,8 +50,8 @@ static void ReplaceMemReadOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
   if (val_type->isX86_FP80Ty() || val_type->isFP128Ty()) {
     val = ir.CreateFPTrunc(val, call_inst->getType());
   }
-  auto* val_inst = llvm::dyn_cast<llvm::Instruction>(val);
-  call_inst->copyMetadata(*val_inst);
+  auto *val_inst = llvm::dyn_cast<llvm::Instruction>(val);
+  val_inst->copyMetadata(*call_inst);
   call_inst->replaceAllUsesWith(val);
   call_inst->eraseFromParent();
 }
@@ -69,8 +69,8 @@ static void ReplaceMemWriteOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
   }
 
   val = ir.CreateStore(val, ptr);
-  auto* val_inst = llvm::dyn_cast<llvm::Instruction>(val);
-  call_inst->copyMetadata(*val_inst);
+  auto *val_inst = llvm::dyn_cast<llvm::Instruction>(val);
+  val_inst->copyMetadata(*call_inst);
   call_inst->replaceAllUsesWith(mem_ptr);
   call_inst->eraseFromParent();
 }

--- a/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
@@ -46,12 +46,13 @@ static void ReplaceMemReadOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
   auto addr = call_inst->getArgOperand(1);
   llvm::IRBuilder<> ir(call_inst);
   auto ptr = ir.CreateIntToPtr(addr, llvm::PointerType::get(val_type, 0));
+  CopyMetadataTo(call_inst, ptr);
   llvm::Value *val = ir.CreateLoad(ptr);
+  CopyMetadataTo(call_inst, val);
   if (val_type->isX86_FP80Ty() || val_type->isFP128Ty()) {
     val = ir.CreateFPTrunc(val, call_inst->getType());
+    CopyMetadataTo(call_inst, val);
   }
-  auto *val_inst = llvm::dyn_cast<llvm::Instruction>(val);
-  val_inst->copyMetadata(*call_inst);
   call_inst->replaceAllUsesWith(val);
   call_inst->eraseFromParent();
 }
@@ -64,13 +65,14 @@ static void ReplaceMemWriteOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
 
   llvm::IRBuilder<> ir(call_inst);
   auto ptr = ir.CreateIntToPtr(addr, llvm::PointerType::get(val_type, 0));
+  CopyMetadataTo(call_inst, ptr);
   if (val_type->isX86_FP80Ty() || val_type->isFP128Ty()) {
     val = ir.CreateFPExt(val, val_type);
+    CopyMetadataTo(call_inst, val);
   }
 
   val = ir.CreateStore(val, ptr);
-  auto *val_inst = llvm::dyn_cast<llvm::Instruction>(val);
-  val_inst->copyMetadata(*call_inst);
+  CopyMetadataTo(call_inst, val);
   call_inst->replaceAllUsesWith(mem_ptr);
   call_inst->eraseFromParent();
 }

--- a/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerRemillMemoryAccessIntrinsics.cpp
@@ -50,6 +50,8 @@ static void ReplaceMemReadOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
   if (val_type->isX86_FP80Ty() || val_type->isFP128Ty()) {
     val = ir.CreateFPTrunc(val, call_inst->getType());
   }
+  auto* val_inst = llvm::dyn_cast<llvm::Instruction>(val);
+  call_inst->copyMetadata(*val_inst);
   call_inst->replaceAllUsesWith(val);
   call_inst->eraseFromParent();
 }
@@ -66,7 +68,9 @@ static void ReplaceMemWriteOp(llvm::CallBase *call_inst, llvm::Type *val_type) {
     val = ir.CreateFPExt(val, val_type);
   }
 
-  (void) ir.CreateStore(val, ptr);
+  val = ir.CreateStore(val, ptr);
+  auto* val_inst = llvm::dyn_cast<llvm::Instruction>(val);
+  call_inst->copyMetadata(*val_inst);
   call_inst->replaceAllUsesWith(mem_ptr);
   call_inst->eraseFromParent();
 }

--- a/libraries/anvill_passes/src/LowerRemillUndefinedIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerRemillUndefinedIntrinsics.cpp
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Utils.h"
+
 #include <anvill/ABI.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/InstIterator.h>
@@ -23,8 +25,6 @@
 #include <llvm/Pass.h>
 
 #include <vector>
-
-#include "Utils.h"
 
 namespace anvill {
 namespace {

--- a/libraries/anvill_passes/src/LowerRemillUndefinedIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerRemillUndefinedIntrinsics.cpp
@@ -17,12 +17,14 @@
 
 #include <anvill/ABI.h>
 #include <llvm/IR/Constants.h>
-#include <llvm/IR/Instructions.h>
 #include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Pass.h>
 
 #include <vector>
+
+#include "Utils.h"
 
 namespace anvill {
 namespace {
@@ -54,7 +56,9 @@ bool LowerRemillUndefinedIntrinsics::runOnFunction(llvm::Function &func) {
 
   auto changed = false;
   for (auto call : calls) {
-    call->replaceAllUsesWith(llvm::UndefValue::get(call->getType()));
+    auto *undef_val = llvm::UndefValue::get(call->getType());
+    CopyMetadataTo(call, undef_val);
+    call->replaceAllUsesWith(undef_val);
     call->eraseFromParent();
     changed = true;
   }

--- a/libraries/anvill_passes/src/LowerTypeHintIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerTypeHintIntrinsics.cpp
@@ -16,13 +16,15 @@
  */
 
 #include <anvill/ABI.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/InstIterator.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Pass.h>
 
 #include <vector>
+
+#include "Utils.h"
 
 namespace anvill {
 namespace {
@@ -56,8 +58,9 @@ bool LowerTypeHintIntrinsics::runOnFunction(llvm::Function &func) {
   for (auto call : calls) {
     auto val = call->getArgOperand(0)->stripPointerCasts();
     llvm::IRBuilder<> ir(call);
-    call->replaceAllUsesWith(
-        ir.CreateBitOrPointerCast(val, call->getType()));
+    auto *cast_val = ir.CreateBitOrPointerCast(val, call->getType());
+    CopyMetadataTo(call, cast_val);
+    call->replaceAllUsesWith(cast_val);
     changed = true;
   }
 

--- a/libraries/anvill_passes/src/LowerTypeHintIntrinsics.cpp
+++ b/libraries/anvill_passes/src/LowerTypeHintIntrinsics.cpp
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Utils.h"
+
 #include <anvill/ABI.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InstIterator.h>
@@ -23,8 +25,6 @@
 #include <llvm/Pass.h>
 
 #include <vector>
-
-#include "Utils.h"
 
 namespace anvill {
 namespace {

--- a/libraries/anvill_passes/src/RecoverEntityUseInformation.cpp
+++ b/libraries/anvill_passes/src/RecoverEntityUseInformation.cpp
@@ -183,12 +183,14 @@ RecoverEntityUseInformation::UpdateFunction(llvm::Function &function,
         var_address = maybe_prev_var_decl->address;
         entity = entity_lifter.LiftEntity(*maybe_prev_var_decl);
       }
+      CopyMetadataTo(val, entity);
 
       // TODO(pag): Can we do better than an `i8 *`?
       if (entity && is_var && var_address < ra.u.address) {
         auto i8_ptr_ty = llvm::Type::getInt8PtrTy(context);
         entity = remill::BuildPointerToOffset(
             ir, entity, ra.u.address - var_address, i8_ptr_ty);
+        CopyMetadataTo(val, entity);
       }
     }
 
@@ -198,11 +200,14 @@ RecoverEntityUseInformation::UpdateFunction(llvm::Function &function,
             context, dl.getPointerSizeInBits(
                          entity->getType()->getPointerAddressSpace()));
         entity = ir.CreatePtrToInt(entity, intptr_ty);
+        CopyMetadataTo(val, entity);
         entity = ir.CreateZExtOrTrunc(entity, val->getType());
+        CopyMetadataTo(val, entity);
         xref_use.use->set(entity);
 
       } else if (val_type->isPointerTy()) {
         entity = ir.CreatePointerBitCastOrAddrSpaceCast(entity, val_type);
+        CopyMetadataTo(val, entity);
         xref_use.use->set(entity);
 
       } else {

--- a/libraries/anvill_passes/src/RecoverStackFrameInformation.cpp
+++ b/libraries/anvill_passes/src/RecoverStackFrameInformation.cpp
@@ -413,6 +413,7 @@ RecoverStackFrameInformation::UpdateFunction(
     auto stack_frame_ptr = builder.CreateGEP(
         stack_frame_alloca, {builder.getInt32(0), builder.getInt32(0),
                              builder.getInt32(zero_based_offset)});
+    CopyMetadataTo(sp_use.use->get(), stack_frame_ptr);
 
     stack_frame_ptr = builder.CreateBitOrPointerCast(
         stack_frame_ptr, obj->getType());
@@ -420,6 +421,7 @@ RecoverStackFrameInformation::UpdateFunction(
     // We now have to replace the operand; it is not correct to use
     // `replaceAllUsesWith` on the operand, because the scope of a constant
     // could be bigger than just the function we are using.
+    CopyMetadataTo(sp_use.use->get(), stack_frame_ptr);
     sp_use.use->set(stack_frame_ptr);
   }
 

--- a/libraries/anvill_passes/src/RemoveDelaySlotIntrinsics.cpp
+++ b/libraries/anvill_passes/src/RemoveDelaySlotIntrinsics.cpp
@@ -57,6 +57,7 @@ bool RemoveDelaySlotIntrinsics::runOnFunction(llvm::Function &func) {
 
   for (llvm::CallBase *call : calls) {
     auto mem_ptr = call->getArgOperand(0);
+    CopyMetadataTo(call, mem_ptr);
     call->replaceAllUsesWith(mem_ptr);
     call->eraseFromParent();
   }

--- a/libraries/anvill_passes/src/RemoveRemillFunctionReturns.cpp
+++ b/libraries/anvill_passes/src/RemoveRemillFunctionReturns.cpp
@@ -15,8 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <anvill/Analysis/CrossReferenceResolver.h>
+#include "Utils.h"
+
 #include <anvill/Analysis/Utils.h>
+#include <anvill/Analysis/CrossReferenceResolver.h>
 #include <anvill/Transforms.h>
 #include <glog/logging.h>
 #include <llvm/ADT/Triple.h>
@@ -34,8 +36,6 @@
 
 #include <utility>
 #include <vector>
-
-#include "Utils.h"
 
 namespace anvill {
 namespace {

--- a/libraries/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp
+++ b/libraries/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp
@@ -141,6 +141,7 @@ void SinkSelectionsIntoBranchTargets::SinkSelectInstructions(
     const FunctionAnalysis &analysis) {
 
   for (const auto &replacement : analysis.replacement_list) {
+    CopyMetadataTo(replacement.use_to_replace->get(), replacement.replace_with);
     replacement.use_to_replace->set(replacement.replace_with);
   }
 

--- a/libraries/anvill_passes/src/SplitStackFrameAtReturnAddress.cpp
+++ b/libraries/anvill_passes/src/SplitStackFrameAtReturnAddress.cpp
@@ -429,6 +429,7 @@ SplitStackFrameAtReturnAddress::SplitStackFrame(
         stack_frame_part.alloca_instr,
         {builder.getInt32(0), builder.getInt32(0), builder.getInt32(offset)});
 
+    CopyMetadataTo(gep_instr.instr, new_gep);
     gep_instr.instr->replaceAllUsesWith(new_gep);
   }
 
@@ -456,6 +457,7 @@ SplitStackFrameAtReturnAddress::SplitStackFrame(
   // usages with the first stack frame part
   if (!stack_analysis.stack_frame_alloca->use_empty()) {
     auto &first_stack_frame_part = allocated_part_list.front();
+    CopyMetadataTo(stack_analysis.stack_frame_alloca, first_stack_frame_part.alloca_instr);
 
     stack_analysis.stack_frame_alloca->replaceAllUsesWith(
         first_stack_frame_part.alloca_instr);

--- a/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
+++ b/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Utils.h"
+
 #include <anvill/Analysis/CrossReferenceResolver.h>
 #include <anvill/Analysis/Utils.h>
 #include <anvill/Lifters/EntityLifter.h>
@@ -38,8 +40,6 @@
 
 #include <utility>
 #include <vector>
-
-#include "Utils.h"
 
 
 namespace anvill {

--- a/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
+++ b/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
@@ -39,6 +39,8 @@
 #include <utility>
 #include <vector>
 
+#include "Utils.h"
+
 
 namespace anvill {
 namespace {
@@ -158,6 +160,7 @@ bool TransformRemillJumpIntrinsics::TransformJumpIntrinsic(
     // undef state pointer argument
     auto state_ptr_arg = call->getArgOperand(remill::kStatePointerArgNum);
     auto undef_val = llvm::UndefValue::get(state_ptr_arg->getType());
+    CopyMetadataTo(state_ptr_arg, undef_val);
     call->setArgOperand(remill::kStatePointerArgNum, undef_val);
 
     call->setCalledOperand(intrinsic);

--- a/libraries/anvill_passes/src/Utils.cpp
+++ b/libraries/anvill_passes/src/Utils.cpp
@@ -180,4 +180,13 @@ bool BasicBlockIsSane(llvm::BasicBlock *block) {
   return true;
 }
 
+void CopyMetadataTo(llvm::Value *src, llvm::Value *dst) {
+  llvm::Instruction *src_inst = llvm::dyn_cast<llvm::Instruction>(src),
+                    *dst_inst = llvm::dyn_cast<llvm::Instruction>(dst);
+  if (src_inst && dst_inst) {
+    dst_inst->copyMetadata(*src_inst);
+  }
+}
+
+
 }  // namespace anvill

--- a/libraries/anvill_passes/src/Utils.cpp
+++ b/libraries/anvill_passes/src/Utils.cpp
@@ -181,8 +181,8 @@ bool BasicBlockIsSane(llvm::BasicBlock *block) {
 }
 
 void CopyMetadataTo(llvm::Value *src, llvm::Value *dst) {
-  llvm::Instruction *src_inst = llvm::dyn_cast<llvm::Instruction>(src),
-                    *dst_inst = llvm::dyn_cast<llvm::Instruction>(dst);
+  llvm::Instruction *src_inst = llvm::dyn_cast_or_null<llvm::Instruction>(src),
+                    *dst_inst = llvm::dyn_cast_or_null<llvm::Instruction>(dst);
   if (src_inst && dst_inst) {
     dst_inst->copyMetadata(*src_inst);
   }

--- a/libraries/anvill_passes/src/Utils.h
+++ b/libraries/anvill_passes/src/Utils.h
@@ -54,4 +54,7 @@ std::string GetFunctionIR(llvm::Function &func);
 // Returns the module's IR
 std::string GetModuleIR(llvm::Module &module);
 
+// Copies metadata from the source to destination if both values are instructions.
+void CopyMetadataTo(llvm::Value *src, llvm::Value *dst);
+
 }  // namespace anvill


### PR DESCRIPTION
@pgoodman 
I wanted to check in and make sure that I have the right idea here. I looked through Anvill's passes for spots where we replace instructions and copied the metadata across.

The remaining passes seem to either be removing instructions entirely (so no need to propagate anything) or the new instructions don't seem to map to an existing one (`RecoverStackFrameInformation` and `SplitStackFrameAtReturnAddress`). So I've left those untouched.

Also, is there a way to verify this patch? From what I can see, the unit tests just run the pass over some LLVM IR and check that it succeeds.