### PR TITLE
Handle i128 arg types for arm64

### DIFF
--- a/anvill/python/anvill/binja/bnfunction.py
+++ b/anvill/python/anvill/binja/bnfunction.py
@@ -28,6 +28,14 @@ from .xreftype import *
 from anvill.function import *
 from anvill.type import *
 
+def should_ignore_register(bv, reg_name):
+    _IGNORE_REGS_LIST = {
+        "aarch64": ["XZR", "WZR"]
+    }
+    try:
+        return (reg_name.upper() in _IGNORE_REGS_LIST[bv.arch.name])
+    except KeyError:
+        return False
 
 class BNFunction(Function):
     def __init__(
@@ -83,6 +91,9 @@ class BNFunction(Function):
             for inst in block:
                 register_information = self._extract_types(program, inst.operands, inst)
                 for reg_info in register_information:
+                    if should_ignore_register(program.bv, reg_info[0]):
+                        continue
+
                     loc = Location()
                     loc.set_register(reg_info[0].upper())
                     loc.set_type(reg_info[1])
@@ -152,6 +163,9 @@ class BNFunction(Function):
         rdi, rsi as operands in the MLIL, we should check if they have pointer information)
         """
         results = []
+        if not (item_or_list and str(item_or_list)):
+            return results
+
         if isinstance(item_or_list, list):
             for item in item_or_list:
                 results.extend(self._extract_types(program, item, initial_inst))
@@ -165,24 +179,27 @@ class BNFunction(Function):
             if (not bn.LLIL_REG_IS_TEMP(item_or_list.index)) and (
                 item_or_list.name not in ["x87control", "x87status"]
             ):
-                # For every register, is it a pointer?
-                possible_pointer: bn.function.RegisterValue = (
-                    initial_inst.get_reg_value(item_or_list.name)
-                )
-                if (
-                    possible_pointer.type
-                    == bn.function.RegisterValueType.ConstantPointerValue
-                    or possible_pointer.type
-                    == bn.function.RegisterValueType.ExternalPointerValue
-                ):  # or
-                    # possible_pointer.type == bn.function.RegisterValueType.ConstantValue:
-                    # Is there a scenario where a register has a ConstantValue type thats used as a pointer?
-                    val_type = _convert_bn_llil_type(
-                        possible_pointer, item_or_list.info.size
-                    )
-                    results.append(
-                        (item_or_list.name, val_type, possible_pointer.value)
-                    )
+                try:
+                    # For every register, is it a pointer?
+                    possible_pointer: bn.function.RegisterValue = (
+                        initial_inst.get_reg_value(item_or_list.name)
+                        )
+                    if (
+                        possible_pointer.type
+                        == bn.function.RegisterValueType.ConstantPointerValue
+                        or possible_pointer.type
+                        == bn.function.RegisterValueType.ExternalPointerValue
+                    ):  # or
+                        # possible_pointer.type == bn.function.RegisterValueType.ConstantValue:
+                        # Is there a scenario where a register has a ConstantValue type thats used as a pointer?
+                        val_type = _convert_bn_llil_type(
+                            possible_pointer, item_or_list.info.size
+                        )
+                        results.append(
+                            (item_or_list.name, val_type, possible_pointer.value)
+                        )
+                except KeyError:
+                    DEBUG(f"Unsupported register {item_or_list.name}")
 
                 if initial_inst.mlil is not None:
                     mlil_results = self._extract_types_mlil(

--- a/anvill/python/anvill/binja/bnfunction.py
+++ b/anvill/python/anvill/binja/bnfunction.py
@@ -163,6 +163,9 @@ class BNFunction(Function):
         rdi, rsi as operands in the MLIL, we should check if they have pointer information)
         """
         results = []
+
+        # item_or_list could be empty string, return early in such cases. The unimplemented
+        # operand shows up as empty string.
         if not (item_or_list and str(item_or_list)):
             return results
 

--- a/anvill/python/anvill/binja/bnfunction.py
+++ b/anvill/python/anvill/binja/bnfunction.py
@@ -28,14 +28,14 @@ from .xreftype import *
 from anvill.function import *
 from anvill.type import *
 
+
 def should_ignore_register(bv, reg_name):
-    _IGNORE_REGS_LIST = {
-        "aarch64": ["XZR", "WZR"]
-    }
+    _IGNORE_REGS_LIST = {"aarch64": ["XZR", "WZR"]}
     try:
-        return (reg_name.upper() in _IGNORE_REGS_LIST[bv.arch.name])
+        return reg_name.upper() in _IGNORE_REGS_LIST[bv.arch.name]
     except KeyError:
         return False
+
 
 class BNFunction(Function):
     def __init__(
@@ -183,7 +183,7 @@ class BNFunction(Function):
                     # For every register, is it a pointer?
                     possible_pointer: bn.function.RegisterValue = (
                         initial_inst.get_reg_value(item_or_list.name)
-                        )
+                    )
                     if (
                         possible_pointer.type
                         == bn.function.RegisterValueType.ConstantPointerValue
@@ -215,7 +215,7 @@ class BNFunction(Function):
                 seg = program.bv.get_segment_at(ea)
                 br.seek(ea)
 
-                #NOTE(artem): This is a workaround for binary ninja's fake
+                # NOTE(artem): This is a workaround for binary ninja's fake
                 # .externs section, which is (correctly) mapped as
                 # not readable, not writable, and not executable.
                 # because it is a fictional creation of the disassembler.

--- a/anvill/python/anvill/binja/bnprogram.py
+++ b/anvill/python/anvill/binja/bnprogram.py
@@ -148,7 +148,9 @@ class BNProgram(Program):
 
         variable = self._bv.get_data_var_at(function_start)
         func = BNFunction(variable, arch, function_start, [], [], func_type, True)
-        DEBUG(f"Created a new function from address: [{func.name()}] at 0x{func.address():x} with 0 arguments")
+        DEBUG(
+            f"Created a new function from address: [{func.name()}] at 0x{func.address():x} with 0 arguments"
+        )
         return func
 
     def _get_function_parameters(self, bn_func):
@@ -166,7 +168,9 @@ class BNProgram(Program):
             self._arch, bn_func, bn_func.calling_convention
         )
 
-        DEBUG(f"Looking at function parameters for {bn_func.name} with {len(bn_func.parameter_vars)} parameters.")
+        DEBUG(
+            f"Looking at function parameters for {bn_func.name} with {len(bn_func.parameter_vars)} parameters."
+        )
         try:
             for var in bn_func.parameter_vars:
                 source_type = var.source_type
@@ -267,7 +271,9 @@ class BNProgram(Program):
                 ret_list.append(loc)
 
         func = BNFunction(bn_func, arch, address, param_list, ret_list, func_type)
-        DEBUG(f"Created a new function from address: [{func.name()}] at 0x{func.address():x} with {len(param_list)} arguments")
+        DEBUG(
+            f"Created a new function from address: [{func.name()}] at 0x{func.address():x} with {len(param_list)} arguments"
+        )
         return func
 
     def get_symbols_impl(self, address):
@@ -389,10 +395,10 @@ class BNProgram(Program):
                             )
 
                             DEBUG(
-                                    "anvill: Adding target list {:x} -> [{:x}, complete=True] for {}".format(
-                                        jump_addr, redirection_dest, function_thunk.name
-                                        )
-                                    )
+                                "anvill: Adding target list {:x} -> [{:x}, complete=True] for {}".format(
+                                    jump_addr, redirection_dest, function_thunk.name
+                                )
+                            )
 
         # Now check whether we successfully redirected all thunks
         for function_thunk in function_thunk_list:

--- a/anvill/src/Arch/AArch64_C.cpp
+++ b/anvill/src/Arch/AArch64_C.cpp
@@ -42,6 +42,14 @@ static const std::vector<RegisterConstraint> kParamRegConstraints = {
                         VariantConstraint("X6", kTypeIntegral, kMaxBit64)}),
     RegisterConstraint({VariantConstraint("W7", kTypeIntegral, kMaxBit32),
                         VariantConstraint("X7", kTypeIntegral, kMaxBit64)}),
+    RegisterConstraint({VariantConstraint("V0", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V1", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V2", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V3", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V4", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V5", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V6", kTypeIntegral, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("V7", kTypeIntegral, kMaxBit128)}),
 
     RegisterConstraint({VariantConstraint("H0", kTypeFloat, kMaxBit16),
                         VariantConstraint("S0", kTypeFloat, kMaxBit32),
@@ -67,6 +75,15 @@ static const std::vector<RegisterConstraint> kParamRegConstraints = {
     RegisterConstraint({VariantConstraint("H7", kTypeFloat, kMaxBit16),
                         VariantConstraint("S7", kTypeFloat, kMaxBit32),
                         VariantConstraint("D7", kTypeFloat, kMaxBit64)}),
+    RegisterConstraint({VariantConstraint("Q0", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q1", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q2", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q3", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q4", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q5", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q6", kTypeFloat, kMaxBit128)}),
+    RegisterConstraint({VariantConstraint("Q7", kTypeFloat, kMaxBit128)}),
+
 };
 
 // TODO(pag): Probably totally broken.

--- a/tools/decompile-json/src/main.cpp
+++ b/tools/decompile-json/src/main.cpp
@@ -67,7 +67,8 @@ DEFINE_string(bc_out, "",
               "Path to file where the LLVM bitcode should be "
               "saved.");
 
-DEFINE_bool(add_breakpoints, false, "Add breakpoint_XXXXXXXX functions to the "
+DEFINE_bool(add_breakpoints, false,
+            "Add breakpoint_XXXXXXXX functions to the "
             "lifted bitcode.");
 
 DEFINE_bool(enable_provenance, false,


### PR DESCRIPTION
Ignore `xzr` register for arm64 and unsupported registers in x86 binaries. Handle i128 parameter types in arm64.