### PR TITLE
wip: enable caching instructions in xref resolver

### DIFF
--- a/anvill/include/anvill/Analysis/CrossReferenceResolver.h
+++ b/anvill/include/anvill/Analysis/CrossReferenceResolver.h
@@ -126,7 +126,8 @@ class CrossReferenceResolver {
   void ClearCache(void) const;
 
   // Try to resolve `val` as a cross-reference.
-  ResolvedCrossReference TryResolveReference(llvm::Value *val) const;
+  ResolvedCrossReference TryResolveReference(llvm::Value *val,
+                                             bool uses_cache = false) const;
 
   // Returns the "magic" value that represents the return address.
   uint64_t MagicReturnAddressValue(void) const;

--- a/anvill/include/anvill/Analysis/CrossReferenceResolver.h
+++ b/anvill/include/anvill/Analysis/CrossReferenceResolver.h
@@ -125,9 +125,12 @@ class CrossReferenceResolver {
   // Clear the internal cache.
   void ClearCache(void) const;
 
-  // Try to resolve `val` as a cross-reference.
-  ResolvedCrossReference TryResolveReference(llvm::Value *val,
-                                             bool uses_cache = false) const;
+  // Try to resolve `val` as a cross-reference with xrefs caching
+  ResolvedCrossReference TryResolveReferenceWithCaching(llvm::Value *val) const;
+
+  // Try to resolve `val` as a cross-reference with cleared xrefs cache
+  ResolvedCrossReference
+  TryResolveReferenceWithClearedCache(llvm::Value *val) const;
 
   // Returns the "magic" value that represents the return address.
   uint64_t MagicReturnAddressValue(void) const;

--- a/libraries/anvill_passes/src/RecoverEntityUseInformation.cpp
+++ b/libraries/anvill_passes/src/RecoverEntityUseInformation.cpp
@@ -90,7 +90,7 @@ EntityUsages RecoverEntityUseInformation::EnumeratePossibleEntityUsages(
           continue;
         }
 
-        if (auto ra = xref_resolver.TryResolveReference(val);
+        if (auto ra = xref_resolver.TryResolveReferenceWithClearedCache(val);
             ra.is_valid && !ra.references_return_address &&
             !ra.references_stack_pointer) {
 

--- a/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
+++ b/libraries/anvill_passes/src/TransformRemillJumpIntrinsics.cpp
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Utils.h"
-
 #include <anvill/Analysis/CrossReferenceResolver.h>
 #include <anvill/Analysis/Utils.h>
 #include <anvill/Lifters/EntityLifter.h>
@@ -40,6 +38,8 @@
 
 #include <utility>
 #include <vector>
+
+#include "Utils.h"
 
 
 namespace anvill {
@@ -100,7 +100,7 @@ TransformRemillJumpIntrinsics::QueryReturnAddress(llvm::Module *module,
   // `__anvill_ra`, and then if we find this magic value on something that
   // references `__anvill_ra`, then we conclude that all those manipulations
   // in the constant expression are actually not important.
-  } else if (auto xr = xref_resolver_.TryResolveReference(val);
+  } else if (auto xr = xref_resolver_.TryResolveReferenceWithClearedCache(val);
              xr.is_valid && xr.references_return_address &&
              xr.u.address == xref_resolver_.MagicReturnAddressValue()) {
     return kReturnAddressProgramCounter;


### PR DESCRIPTION
Enabled caching of instruction in xref resolver to avoid exploding the states while doing the lookup and resolving cross references. The caching is also added while looking for the value derived from symbolic stack. 