### PR TITLE
Detect sub architecture of amd64 in python

### DIFF
--- a/anvill/python/anvill/arch.py
+++ b/anvill/python/anvill/arch.py
@@ -370,13 +370,13 @@ class AMD64Arch(Arch):
 
     def register_name(self, reg_name) -> Register:
         if reg_name.startswith("%"):
-            ret_name = reg_name[1:].upper()
+            reg_name = reg_name[1:].upper()
         else:
-            ret_name = reg_name.upper()
+            reg_name = reg_name.upper()
 
-        if ret_name.startswith("ZMM"):
+        if reg_name.startswith("ZMM"):
             self._has_avx512 = True
-        elif ret_name.startswith("YMM"):
+        elif reg_name.startswith("YMM"):
             self._has_avx = True
 
         return reg_name
@@ -630,13 +630,13 @@ class X86Arch(Arch):
 
     def register_name(self, reg_name) -> Register:
         if reg_name.startswith("%"):
-            ret_name = reg_name[1:].upper()
+            reg_name = reg_name[1:].upper()
         else:
-            ret_name = reg_name.upper()
+            reg_name = reg_name.upper()
 
-        if ret_name.startswith("ZMM"):
+        if reg_name.startswith("ZMM"):
             self._has_avx512 = True
-        elif ret_name.startswith("YMM"):
+        elif reg_name.startswith("YMM"):
             self._has_avx = True
 
         return reg_name

--- a/anvill/python/anvill/arch.py
+++ b/anvill/python/anvill/arch.py
@@ -369,12 +369,17 @@ class AMD64Arch(Arch):
         return self._REG_FAMILY[self.register_name(reg_name)]
 
     def register_name(self, reg_name) -> Register:
-        self._has_avx |= any(reg in reg_name for reg in ["xmm", "ymm", "XMM", "YMM"])
-        self._has_avx512 |= any(reg in reg_name for reg in ["zmm", "ZMM"])
         if reg_name.startswith("%"):
-            return reg_name[1:].upper()
+            ret_name = reg_name[1:].upper()
         else:
-            return reg_name.upper()
+            ret_name = reg_name.upper()
+
+        if ret_name.startswith("ZMM"):
+            self._has_avx512 = True
+        elif ret_name.startswith("YMM"):
+            self._has_avx = True
+
+        return reg_name
 
 
 class X86Arch(Arch):
@@ -624,12 +629,17 @@ class X86Arch(Arch):
         return self._REG_FAMILY[self.register_name(reg_name)]
 
     def register_name(self, reg_name) -> Register:
-        self._has_avx |= any(reg in reg_name for reg in ["xmm", "ymm", "XMM", "YMM"])
-        self._has_avx512 |= any(reg in reg_name for reg in ["zmm", "ZMM"])
         if reg_name.startswith("%"):
-            return reg_name[1:].upper()
+            ret_name = reg_name[1:].upper()
         else:
-            return reg_name.upper()
+            ret_name = reg_name.upper()
+
+        if ret_name.startswith("ZMM"):
+            self._has_avx512 = True
+        elif ret_name.startswith("YMM"):
+            self._has_avx = True
+
+        return reg_name
 
 
 class AArch64Arch(Arch):

--- a/anvill/python/anvill/arch.py
+++ b/anvill/python/anvill/arch.py
@@ -66,6 +66,9 @@ class Arch(ABC):
 class AMD64Arch(Arch):
     """AMD64-specific architecture description (64-bit)."""
 
+    _has_avx = False
+    _has_avx512 = False
+
     _REG_FAMILY_rX = lambda l: (
         ("R{}X".format(l), 0, 8),
         ("E{}X".format(l), 0, 4),
@@ -337,7 +340,12 @@ class AMD64Arch(Arch):
     }
 
     def name(self) -> ArchName:
-        return "amd64"
+        if self._has_avx512:
+            return "amd64_avx512"
+        elif self._has_avx:
+            return "amd64_avx"
+        else:
+            return "amd64"
 
     def program_counter_name(self) -> Register:
         return "RIP"
@@ -361,6 +369,8 @@ class AMD64Arch(Arch):
         return self._REG_FAMILY[self.register_name(reg_name)]
 
     def register_name(self, reg_name) -> Register:
+        self._has_avx |= any(reg in reg_name for reg in ["xmm", "ymm", "XMM", "YMM"])
+        self._has_avx512 |= any(reg in reg_name for reg in ["zmm", "ZMM"])
         if reg_name.startswith("%"):
             return reg_name[1:].upper()
         else:
@@ -369,6 +379,9 @@ class AMD64Arch(Arch):
 
 class X86Arch(Arch):
     """X86-specific architecture description (32-bit)."""
+
+    _has_avx = False
+    _has_avx512 = False
 
     _REG_FAMILY_rX = lambda l: (
         ("E{}X".format(l), 0, 4),
@@ -582,7 +595,12 @@ class X86Arch(Arch):
     }
 
     def name(self) -> ArchName:
-        return "x86"
+        if self._has_avx512:
+            return "x86_avx512"
+        elif self._has_avx:
+            return "x86_avx"
+        else:
+            return "x86"
 
     def program_counter_name(self) -> Register:
         return "EIP"
@@ -606,6 +624,8 @@ class X86Arch(Arch):
         return self._REG_FAMILY[self.register_name(reg_name)]
 
     def register_name(self, reg_name) -> Register:
+        self._has_avx |= any(reg in reg_name for reg in ["xmm", "ymm", "XMM", "YMM"])
+        self._has_avx512 |= any(reg in reg_name for reg in ["zmm", "ZMM"])
         if reg_name.startswith("%"):
             return reg_name[1:].upper()
         else:

--- a/anvill/python/anvill/binja/bnfunction.py
+++ b/anvill/python/anvill/binja/bnfunction.py
@@ -91,11 +91,13 @@ class BNFunction(Function):
             for inst in block:
                 register_information = self._extract_types(program, inst.operands, inst)
                 for reg_info in register_information:
-                    if should_ignore_register(program.bv, reg_info[0]):
+                    if should_ignore_register(
+                        program.bv, self._arch.register_name(reg_info[0])
+                    ):
                         continue
 
                     loc = Location()
-                    loc.set_register(reg_info[0].upper())
+                    loc.set_register(self._arch.register_name(reg_info[0]))
                     loc.set_type(reg_info[1])
                     if reg_info[2] is not None:
                         # fill_bytes misses some references, catch what we can


### PR DESCRIPTION
The changes scan the registers and detect correct sub-architecture if xmm/ymm/zmm registers getting used. (#219) 