### PR TITLE
Adds Temporary Intrinsic Removal Pass

### DIFF
--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -149,6 +149,7 @@ void OptimizeModule(const EntityLifter &lifter_context,
   auto error_manager_ptr = ITransformationErrorManager::Create();
   auto &err_man = *error_manager_ptr.get();
 
+  AddRemoveComparisonAndBranchIntrinsics(fpm);
   AddSinkSelectionsIntoBranchTargets(fpm, err_man);
   AddRemoveUnusedFPClassificationCalls(fpm);
   AddRemoveDelaySlotIntrinsics(fpm);
@@ -165,11 +166,12 @@ void OptimizeModule(const EntityLifter &lifter_context,
   AddRemoveTrivialPhisAndSelects(fpm);
 
   fpm.addPass(llvm::DCEPass());
+  AddRemoveStackPointerCExprs(fpm);
   AddRecoverStackFrameInformation(fpm, err_man, options);
   fpm.addPass(llvm::SROA());
   AddSplitStackFrameAtReturnAddress(fpm, err_man);
   fpm.addPass(llvm::SROA());
-  AddRemoveComparisonAndBranchIntrinsics(fpm);
+
 
   // Sometimes we have a values in the form of (expr ^ 1) used as branch
   // conditions or other targets. Try to fix these to be CMPs, since it

--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -169,6 +169,7 @@ void OptimizeModule(const EntityLifter &lifter_context,
   fpm.addPass(llvm::SROA());
   AddSplitStackFrameAtReturnAddress(fpm, err_man);
   fpm.addPass(llvm::SROA());
+  AddRemoveComparisonAndBranchIntrinsics(fpm);
 
   // Sometimes we have a values in the form of (expr ^ 1) used as branch
   // conditions or other targets. Try to fix these to be CMPs, since it

--- a/libraries/anvill_passes/CMakeLists.txt
+++ b/libraries/anvill_passes/CMakeLists.txt
@@ -65,6 +65,9 @@ add_library(anvill_passes STATIC
   src/RemoveBranchAndFlagIntrinsics.h
   src/RemoveBranchAndFlagIntrinsics.cpp
 
+  src/RemoveStackPointerCExprs.cpp
+  src/RemoveStackPointerCExprs.cpp
+
   src/Utils.h
   src/Utils.cpp
   src/SliceManager.cpp

--- a/libraries/anvill_passes/CMakeLists.txt
+++ b/libraries/anvill_passes/CMakeLists.txt
@@ -61,6 +61,10 @@ add_library(anvill_passes STATIC
   src/SwitchLoweringPass.cpp
   src/BaseFunctionPass.h
 
+
+  src/RemoveBranchAndFlagIntrinsics.h
+  src/RemoveBranchAndFlagIntrinsics.cpp
+
   src/Utils.h
   src/Utils.cpp
   src/SliceManager.cpp

--- a/libraries/anvill_passes/include/anvill/Transforms.h
+++ b/libraries/anvill_passes/include/anvill/Transforms.h
@@ -271,4 +271,6 @@ void AddRemoveErrorIntrinsics(llvm::FunctionPassManager &fpm);
 void AddSwitchLoweringPass(llvm::FunctionPassManager &fpm,
                            const std::shared_ptr<MemoryProvider> &memprov,
                            SliceManager &slc);
+
+void AddRemoveComparisonAndBranchIntrinsics(llvm::FunctionPassManager &fpm);
 }  // namespace anvill

--- a/libraries/anvill_passes/include/anvill/Transforms.h
+++ b/libraries/anvill_passes/include/anvill/Transforms.h
@@ -273,4 +273,6 @@ void AddSwitchLoweringPass(llvm::FunctionPassManager &fpm,
                            SliceManager &slc);
 
 void AddRemoveComparisonAndBranchIntrinsics(llvm::FunctionPassManager &fpm);
+
+void AddRemoveStackPointerCExprs(llvm::FunctionPassManager &fpm);
 }  // namespace anvill

--- a/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
+++ b/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
@@ -1,0 +1,38 @@
+
+#include "RemoveBranchAndFlagIntrinsics.h"
+
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/Support/Casting.h>
+namespace anvill {
+
+llvm::PreservedAnalyses
+RemoveBranchAndFlagIntrinsics::run(llvm::Function &F,
+                                   llvm::FunctionAnalysisManager &AM) {
+
+  for (auto &insn : llvm::instructions(F)) {
+    if (auto *call = llvm::dyn_cast<llvm::CallBase>(&insn)) {
+      auto name = call->getCalledFunction()->getName();
+      if (name.startswith(kFlagIntrinsicPrefix) ||
+          name.startswith(kCompareInstrinsicPrefix)) {
+
+        call->replaceAllUsesWith(call->getArgOperand(0));
+        call->eraseFromParent();
+      }
+    }
+  }
+
+
+  return llvm::PreservedAnalyses::none();
+}
+
+
+llvm::StringRef RemoveBranchAndFlagIntrinsics::name(void) {
+  return "RemoveBranchAndFlagIntrinsics";
+}
+
+void AddRemoveComparisonAndBranchIntrinsics(llvm::FunctionPassManager &fpm) {
+  fpm.addPass(RemoveBranchAndFlagIntrinsics());
+}
+}  // namespace anvill

--- a/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
+++ b/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
@@ -5,24 +5,31 @@
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/Casting.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
+
 namespace anvill {
 
 llvm::PreservedAnalyses
 RemoveBranchAndFlagIntrinsics::run(llvm::Function &F,
                                    llvm::FunctionAnalysisManager &AM) {
 
+  std::vector<llvm::Instruction *> to_del;
   for (auto &insn : llvm::instructions(F)) {
     if (auto *call = llvm::dyn_cast<llvm::CallBase>(&insn)) {
       auto name = call->getCalledFunction()->getName();
       if (name.startswith(kFlagIntrinsicPrefix) ||
           name.startswith(kCompareInstrinsicPrefix)) {
 
+
         call->replaceAllUsesWith(call->getArgOperand(0));
-        call->eraseFromParent();
+        to_del.push_back(call);
       }
     }
   }
 
+  for (auto c : to_del) {
+    c->eraseFromParent();
+  }
 
   return llvm::PreservedAnalyses::none();
 }

--- a/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
+++ b/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.cpp
@@ -16,13 +16,16 @@ RemoveBranchAndFlagIntrinsics::run(llvm::Function &F,
   std::vector<llvm::Instruction *> to_del;
   for (auto &insn : llvm::instructions(F)) {
     if (auto *call = llvm::dyn_cast<llvm::CallBase>(&insn)) {
-      auto name = call->getCalledFunction()->getName();
-      if (name.startswith(kFlagIntrinsicPrefix) ||
-          name.startswith(kCompareInstrinsicPrefix)) {
+      auto callee = call->getCalledFunction();
+      if (callee != nullptr) {
+        auto name = callee->getName();
+        if (name.startswith(kFlagIntrinsicPrefix) ||
+            name.startswith(kCompareInstrinsicPrefix)) {
 
 
-        call->replaceAllUsesWith(call->getArgOperand(0));
-        to_del.push_back(call);
+          call->replaceAllUsesWith(call->getArgOperand(0));
+          to_del.push_back(call);
+        }
       }
     }
   }

--- a/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.h
+++ b/libraries/anvill_passes/src/RemoveBranchAndFlagIntrinsics.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+#include <llvm/Pass.h>
+
+
+namespace anvill {
+static constexpr auto kFlagIntrinsicPrefix = "__remill_flag_computation";
+static constexpr auto kCompareInstrinsicPrefix = "__remill_compare";
+class RemoveBranchAndFlagIntrinsics final
+    : llvm::PassInfoMixin<RemoveBranchAndFlagIntrinsics> {
+ public:
+  explicit RemoveBranchAndFlagIntrinsics(void) {}
+
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &AM);
+
+
+  static llvm::StringRef name(void);
+};
+}  // namespace anvill

--- a/libraries/anvill_passes/src/RemoveStackPointerCExprs.cpp
+++ b/libraries/anvill_passes/src/RemoveStackPointerCExprs.cpp
@@ -1,0 +1,85 @@
+
+
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RemoveStackPointerCExprs.h"
+
+#include <anvill/Analysis/CrossReferenceResolver.h>
+#include <anvill/Analysis/Utils.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/ReplaceConstant.h>
+
+#include <iostream>
+
+namespace anvill {
+
+void AddRemoveStackPointerCExprs(llvm::FunctionPassManager &fpm) {
+  fpm.addPass(RemoveStackPointerCExprs());
+}
+
+llvm::PreservedAnalyses
+RemoveStackPointerCExprs::run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &AM) {
+  bool did_see = false;
+
+  CrossReferenceResolver resolver(F.getParent()->getDataLayout());
+  std::vector<llvm::Instruction *> worklist;
+
+  for (auto &insn : llvm::instructions(F)) {
+    worklist.push_back(&insn);
+  }
+
+  did_see = false;
+  while (!worklist.empty()) {
+    auto curr = worklist.back();
+    worklist.pop_back();
+    for (auto &use : curr->operands()) {
+      if (llvm::isa_and_nonnull<llvm::ConstantExpr>(use.get()) &&
+          IsRelatedToStackPointer(F.getParent(), use.get())) {
+
+        auto cexpr = llvm::cast<llvm::ConstantExpr>(use.get());
+        auto maybe_resolved =
+            resolver.TryResolveReferenceWithClearedCache(cexpr);
+
+        //NOTE(ian): Ok new idea we need to split constant expressions iff they are not resolvable to a stack reference with displacement
+        if (!maybe_resolved.is_valid ||
+            !maybe_resolved.references_stack_pointer) {
+
+          did_see = true;
+
+          // NOTE(ian): convertConstantExprsToInstructions in llvm 14 builds multiple replacement instructions for components of the cexpr so we wouldnt need to do this loop
+          // the method for doing this is much better. createReplacementInstr doesnt work because it tries to translate the whole instruction...
+          auto newi = cexpr->getAsInstruction();
+          newi->insertBefore(curr);
+          use.set(newi);
+
+          worklist.push_back(newi);
+        }
+      }
+    }
+  }
+
+  if (did_see) {
+    return llvm::PreservedAnalyses::none();
+  } else {
+    return llvm::PreservedAnalyses::all();
+  }
+}
+}  // namespace anvill

--- a/libraries/anvill_passes/src/RemoveStackPointerCExprs.h
+++ b/libraries/anvill_passes/src/RemoveStackPointerCExprs.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+#include <llvm/Pass.h>
+
+namespace anvill {
+
+// This pass unrolls constant expressions that involve the stack pointer into instructions so that
+// RecoverStackInformation can replace the stack pointer with its stack representation.
+// The pass strips away portions of the constant expression that cant be resolved to a stack reference so that hopefully they
+// will be resolved later.
+
+// define i1 @slice() local_unnamed_addr #2 {
+//     %1 = call zeroext i1 (i1, ...) @__remill_flag_computation_sign(i1 zeroext icmp slt (i32 add (i32 ptrtoint (i8* @__anvill_sp to i32), i32 -12), i32 0), i32 add (i32 ptrtoint (i8* @__anvill_sp to i32), i32 -12)) #5
+//     ret i1 %1
+// }
+
+// Becomes:
+// define i1 @slice() local_unnamed_addr {
+//   %1 = icmp slt i32 add (i32 ptrtoint (i8* @__anvill_sp to i32), i32 -12), 0
+//   %2 = call zeroext i1 (i1, ...) @__remill_flag_computation_sign(i1 zeroext %1, i32 add (i32 ptrtoint (i8* @__anvill_sp to i32), i32 -12))
+//   ret i1 %2
+// }
+// }
+
+class RemoveStackPointerCExprs final
+    : public llvm::PassInfoMixin<RemoveStackPointerCExprs> {
+ public:
+  RemoveStackPointerCExprs(void) {}
+
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &AM);
+};
+
+}  // namespace anvill


### PR DESCRIPTION
This PR removes comparison and branch hint intrinsics to make decompiler output prettier. This is a temporary measure and in the future branch recovery should use these hints to remove them while simplifying the branch. An additional pass should exist in branch recovery that removes failed hints, but this pass should derive from the intrinsic pass infra that already exists on that branch