### PR TITLE
Ian/code quality stats

### DIFF
--- a/anvill/src/Optimize.cpp
+++ b/anvill/src/Optimize.cpp
@@ -56,6 +56,7 @@
 
 #include <anvill/Providers/MemoryProvider.h>
 #include <anvill/JumpTableAnalysis.h>
+#include <anvill/CodeQualityStatCollector.h>
 // clang-format on
 
 #include <anvill/Providers/MemoryProvider.h>
@@ -237,7 +238,7 @@ void OptimizeModule(const EntityLifter &lifter_context,
   AddTransformRemillJumpIntrinsics(second_fpm, lifter_context);
   AddRemoveRemillFunctionReturns(second_fpm, lifter_context);
   AddLowerRemillUndefinedIntrinsics(second_fpm);
-
+  second_fpm.addPass(CodeQualityStatCollector());
 
   mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(second_fpm)));
   mpm.run(module, mam);

--- a/libraries/anvill_passes/CMakeLists.txt
+++ b/libraries/anvill_passes/CMakeLists.txt
@@ -83,6 +83,9 @@ add_library(anvill_passes STATIC
 
   src/ConvertXorToCmp.cpp
   src/ConvertXorToCmp.h
+
+  include/anvill/CodeQualityStatCollector.h
+  src/CodeQualityStatCollector.cpp
 )
 
 target_include_directories(anvill_passes PUBLIC

--- a/libraries/anvill_passes/include/anvill/CodeQualityStatCollector.h
+++ b/libraries/anvill_passes/include/anvill/CodeQualityStatCollector.h
@@ -1,0 +1,15 @@
+#include <llvm/IR/PassManager.h>
+
+// This pass collects additional stats which are useful for measuring code quality.
+
+
+namespace anvill {
+class CodeQualityStatCollector
+    : public llvm::PassInfoMixin<CodeQualityStatCollector> {
+ public:
+  llvm::PreservedAnalyses run(llvm::Function &function,
+                              llvm::FunctionAnalysisManager &analysisManager);
+
+  static llvm::StringRef name(void);
+};
+}  // namespace anvill

--- a/libraries/anvill_passes/src/CodeQualityStatCollector.cpp
+++ b/libraries/anvill_passes/src/CodeQualityStatCollector.cpp
@@ -1,0 +1,86 @@
+
+#define DEBUG_TYPE "code_quality"
+
+#include <anvill/ABI.h>
+#include <anvill/CodeQualityStatCollector.h>
+#include <llvm/ADT/Statistic.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/InstVisitor.h>
+#include <llvm/IR/Instruction.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/PassManager.h>
+
+namespace anvill {
+STATISTIC(
+    ConditionalComplexity,
+    "A factor that approximates the complexity of the condition in branch instructions");
+STATISTIC(NumberOfInstructions, "Total number of instructions");
+STATISTIC(AbruptControlFlow, "Indirect control flow instructions");
+
+
+namespace {
+// The idea here is that we count the number of boolean expressions involved in this branch which should be an indicator of its complexity
+class ConditionalComplexityVisitor
+    : public llvm::InstVisitor<ConditionalComplexityVisitor> {
+
+ public:
+  void tryVisit(llvm::Value *v) {
+    if (auto *insn = llvm::dyn_cast<llvm::Instruction>(v)) {
+      this->visit(insn);
+    }
+  }
+
+  void visitBinaryOperator(llvm::BinaryOperator &I) {
+    if (auto *inttype = llvm::dyn_cast<llvm::IntegerType>(I.getType())) {
+      if (inttype->getBitWidth() == 1) {
+        ConditionalComplexity++;
+        this->tryVisit(I.getOperand(0));
+        this->tryVisit(I.getOperand(1));
+      }
+    }
+  }
+
+  void visitCmpInst(llvm::CmpInst &I) {
+    ConditionalComplexity++;
+  }
+
+  void visitUnaryOperator(llvm::UnaryOperator &I) {
+    if (auto *inttype = llvm::dyn_cast<llvm::IntegerType>(I.getType())) {
+      ConditionalComplexity++;
+      this->tryVisit(I.getOperand(0));
+    }
+  }
+};
+}  // namespace
+
+
+llvm::PreservedAnalyses
+CodeQualityStatCollector::run(llvm::Function &function,
+                              llvm::FunctionAnalysisManager &analysisManager) {
+  ConditionalComplexityVisitor complexity_visitor;
+  for (auto &i : llvm::instructions(function)) {
+    NumberOfInstructions++;
+    if (auto *branch = llvm::dyn_cast<llvm::BranchInst>(&i)) {
+      if (branch->isConditional()) {
+        complexity_visitor.tryVisit(branch->getCondition());
+      }
+    }
+
+    if (auto *cb = llvm::dyn_cast<llvm::CallBase>(&i)) {
+      auto target = cb->getCalledFunction();
+      if (target != nullptr) {
+        if (target->getName() == kAnvillSwitchCompleteFunc ||
+            target->getName() == kAnvillSwitchIncompleteFunc) {
+          AbruptControlFlow++;
+        }
+      }
+    }
+  }
+  return llvm::PreservedAnalyses::all();
+}
+
+llvm::StringRef CodeQualityStatCollector::name(void) {
+  return "CodeQualityStatCollector";
+}
+
+}  // namespace anvill

--- a/scripts/test-amp-challenge-bins.sh
+++ b/scripts/test-amp-challenge-bins.sh
@@ -125,7 +125,8 @@ do
         --output-dir "$(pwd)/results/${dir}" \
         --run-name "anvill-live-ci-amp-bins" \
         --test-options "${SRC_DIR}/ci/challenge_bins_test_settings.json" \
-        --dump-stats
+        --dump-stats \
+        --dump-benchmark
 
 
     if ! check_test "$(pwd)/results/${dir}/python/stats.json"


### PR DESCRIPTION
Adds the ability to dump an llvm stats object during decompilation, and a codequality pass that collects some custom metrics.