### PR TITLE
Fix anvill commiting to default function types for all pointers

### DIFF
--- a/include/anvill/Declarations.h
+++ b/include/anvill/Declarations.h
@@ -108,8 +108,8 @@ struct VariableDecl {
   std::uint64_t address{0};
 
   // Declare this global variable in an LLVM module.
-  llvm::GlobalVariable *DeclareInModule(
-      const std::string &name, llvm::Module &) const;
+  llvm::GlobalVariable *DeclareInModule(const std::string &name,
+                                        llvm::Module &) const;
 };
 
 // A declaration for a callable entity.
@@ -161,19 +161,17 @@ struct CallableDecl {
   bool is_variadic{false};
 
 
-  // This value provides a way for type providers to hint to lifters wether this type can be used to infer an entity is going to exist at this location.
-  bool is_default_decl{false};
-
   // The calling convention of this function.
   llvm::CallingConv::ID calling_convention{0u};
 
   // Interpret `target` as being the function to call, and call it from within
   // a basic block in a lifted bitcode function. Returns the new value of the
   // memory pointer.
-  llvm::Value *CallFromLiftedBlock(
-      llvm::Value *target, const anvill::TypeDictionary &types,
-      const remill::IntrinsicTable &intrinsics, llvm::BasicBlock *block,
-      llvm::Value *state_ptr, llvm::Value *mem_ptr) const;
+  llvm::Value *
+  CallFromLiftedBlock(llvm::Value *target, const anvill::TypeDictionary &types,
+                      const remill::IntrinsicTable &intrinsics,
+                      llvm::BasicBlock *block, llvm::Value *state_ptr,
+                      llvm::Value *mem_ptr) const;
 };
 
 // A function decl, as represented at a "near ABI" level. To be specific,
@@ -205,13 +203,14 @@ struct FunctionDecl : public CallableDecl {
 
   // Create a function declaration from an LLVM function.
   inline static Result<FunctionDecl, std::string>
-  Create(llvm::Function &func, const std::unique_ptr<const remill::Arch> &arch) {
+  Create(llvm::Function &func,
+         const std::unique_ptr<const remill::Arch> &arch) {
     return Create(func, arch.get());
   }
 
   // Create a function declaration from an LLVM function.
-  static Result<FunctionDecl, std::string> Create(
-      llvm::Function &func, const remill::Arch *arch);
+  static Result<FunctionDecl, std::string> Create(llvm::Function &func,
+                                                  const remill::Arch *arch);
 };
 
 // A call site decl, as represented at a "near ABI" level. This is like a

--- a/include/anvill/Declarations.h
+++ b/include/anvill/Declarations.h
@@ -160,6 +160,10 @@ struct CallableDecl {
   // is a variadic function.
   bool is_variadic{false};
 
+
+  // This value provides a way for type providers to hint to lifters wether this type can be used to infer an entity is going to exist at this location.
+  bool is_default_decl{false};
+
   // The calling convention of this function.
   llvm::CallingConv::ID calling_convention{0u};
 

--- a/include/anvill/Providers.h
+++ b/include/anvill/Providers.h
@@ -35,6 +35,30 @@ namespace anvill {
 
 class TypeProvider {
  public:
+  virtual std::optional<FunctionDecl>
+  GetDefaultFunctionType(uint64_t address) const;
+
+  virtual std::optional<VariableDecl>
+  GetDefaultVariableDecl(uint64_t address) const;
+
+
+  std::optional<FunctionDecl>
+  TryGetFuntionTypeOrDefault(uint64_t address) const;
+
+  std::optional<CallableDecl>
+  TryGetCalledFunctionTypeOrDefault(uint64_t function_address,
+                                    const remill::Instruction &from_inst) const;
+
+  std::optional<CallableDecl>
+  TryGetCalledFunctionTypeOrDefault(uint64_t function_address,
+                                    const remill::Instruction &from_inst,
+                                    uint64_t to_address) const;
+
+  std::optional<VariableDecl>
+  TryGetVariableTypeOrDefault(uint64_t address,
+                              llvm::Type *hinted_value_type = nullptr) const;
+
+
   // Try to return the type of a function starting at address `address`. This
   // type is the prototype of the function.
   virtual std::optional<FunctionDecl>
@@ -56,7 +80,7 @@ class TypeProvider {
   // Try to return the variable at given address or containing the address
   virtual std::optional<VariableDecl>
   TryGetVariableType(uint64_t address,
-                     llvm::Type *hinted_value_type=nullptr) const = 0;
+                     llvm::Type *hinted_value_type = nullptr) const = 0;
 
   // Try to get the type of the register named `reg_name` on entry to the
   // instruction at `inst_address` inside the function beginning at
@@ -112,8 +136,9 @@ class NullTypeProvider : public BaseTypeProvider {
   using BaseTypeProvider::BaseTypeProvider;
 
   std::optional<FunctionDecl> TryGetFunctionType(uint64_t) const override;
-  std::optional<VariableDecl> TryGetVariableType(
-      uint64_t, llvm::Type *hinted_value_type=nullptr) const override;
+  std::optional<VariableDecl>
+  TryGetVariableType(uint64_t,
+                     llvm::Type *hinted_value_type = nullptr) const override;
 };
 
 // Delegates to an underlying tye provider to provide the data. Derived from
@@ -147,8 +172,8 @@ class ProxyTypeProvider : public TypeProvider {
 
   // Try to return the variable at given address or containing the address
   std::optional<VariableDecl>
-  TryGetVariableType(
-      uint64_t address, llvm::Type *hinted_value_type=nullptr) const override;
+  TryGetVariableType(uint64_t address,
+                     llvm::Type *hinted_value_type = nullptr) const override;
 
   // Try to get the type of the register named `reg_name` on entry to the
   // instruction at `inst_address` inside the function beginning at
@@ -216,7 +241,7 @@ class SpecificationTypeProvider : public BaseTypeProvider {
 
   std::optional<anvill::VariableDecl>
   TryGetVariableType(uint64_t address,
-                     llvm::Type *hinted_value_type=nullptr) const override;
+                     llvm::Type *hinted_value_type = nullptr) const override;
 
  private:
   SpecificationTypeProvider(void) = delete;

--- a/lib/JSON.cpp
+++ b/lib/JSON.cpp
@@ -448,7 +448,7 @@ JSONTranslator::DecodeDefaultCallableDecl(const llvm::json::Object *obj) const {
   if (!parse_res.Succeeded()) {
     return parse_res.TakeError();
   }
-  decl.is_default_decl = true;
+
   return decl;
 }
 

--- a/lib/JSON.cpp
+++ b/lib/JSON.cpp
@@ -448,6 +448,7 @@ JSONTranslator::DecodeDefaultCallableDecl(const llvm::json::Object *obj) const {
   if (!parse_res.Succeeded()) {
     return parse_res.TakeError();
   }
+  decl.is_default_decl = true;
   return decl;
 }
 

--- a/lib/Lifters/ValueLifter.cpp
+++ b/lib/Lifters/ValueLifter.cpp
@@ -60,8 +60,8 @@ ValueLifterImpl::GetVarPointer(uint64_t var_ea, uint64_t search_ea,
                                llvm::PointerType *opt_ptr_type) const {
   llvm::Type *opt_elem_type =
       opt_ptr_type ? opt_ptr_type->getElementType() : nullptr;
-  auto maybe_var = ent_lifter.type_provider->TryGetVariableType(
-      search_ea, opt_elem_type);
+  auto maybe_var =
+      ent_lifter.type_provider->TryGetVariableType(search_ea, opt_elem_type);
   if (!maybe_var) {
     return nullptr;
   }
@@ -83,7 +83,7 @@ ValueLifterImpl::GetVarPointer(uint64_t var_ea, uint64_t search_ea,
       return llvm::dyn_cast<llvm::Constant>(remill::BuildPointerToOffset(
           builder, enclosing_var, var_ea - maybe_var->address, opt_ptr_type));
 
-    // Otherwise, we need to go with whatever we can.
+      // Otherwise, we need to go with whatever we can.
     } else {
       opt_ptr_type = llvm::Type::getInt8PtrTy(context);
       auto ret = llvm::dyn_cast<llvm::Constant>(remill::BuildPointerToOffset(
@@ -180,7 +180,7 @@ ValueLifterImpl::TryGetPointerForAddress(uint64_t ea,
   }
 
   auto maybe_decl = ent_lifter.type_provider->TryGetFunctionType(ea);
-  if (maybe_decl && !maybe_decl->is_default_decl) {
+  if (maybe_decl) {
     return GetFunctionPointer(*maybe_decl, ent_lifter);
   }
 
@@ -220,9 +220,10 @@ ValueLifterImpl::TryGetPointerForAddress(uint64_t ea,
 // Lift the pointer at address `ea` which is getting referenced by the
 // variable at `loc_ea`. It checks the type and lift them as function
 // or variable pointer
-llvm::Constant *ValueLifterImpl::GetPointer(
-    uint64_t ea, llvm::Type *value_type, EntityLifterImpl &ent_lifter,
-    uint64_t loc_ea, unsigned address_space) const {
+llvm::Constant *ValueLifterImpl::GetPointer(uint64_t ea, llvm::Type *value_type,
+                                            EntityLifterImpl &ent_lifter,
+                                            uint64_t loc_ea,
+                                            unsigned address_space) const {
 
   if (!value_type) {
     value_type = llvm::Type::getInt8Ty(context);
@@ -261,8 +262,8 @@ llvm::Constant *ValueLifterImpl::GetPointer(
 
   std::stringstream ss;
   ss << kGlobalAliasNamePrefix << std::hex << ea << '_'
-     << type_specifier.EncodeToString(
-            type, EncodingFormat::kValidSymbolCharsOnly);
+     << type_specifier.EncodeToString(type,
+                                      EncodingFormat::kValidSymbolCharsOnly);
 
   const auto name = ss.str();
   auto alias_ret = llvm::GlobalAlias::create(value_type, address_space,

--- a/lib/Lifters/ValueLifter.cpp
+++ b/lib/Lifters/ValueLifter.cpp
@@ -180,7 +180,7 @@ ValueLifterImpl::TryGetPointerForAddress(uint64_t ea,
   }
 
   auto maybe_decl = ent_lifter.type_provider->TryGetFunctionType(ea);
-  if (maybe_decl) {
+  if (maybe_decl && !maybe_decl->is_default_decl) {
     return GetFunctionPointer(*maybe_decl, ent_lifter);
   }
 

--- a/lib/Providers/TypeProvider.cpp
+++ b/lib/Providers/TypeProvider.cpp
@@ -252,4 +252,61 @@ const ::anvill::TypeDictionary &ProxyTypeProvider::Dictionary(void) const {
 
 ProxyTypeProvider::ProxyTypeProvider(const TypeProvider &deleg)
     : deleg(deleg) {}
+
+std::optional<FunctionDecl>
+TypeProvider::GetDefaultFunctionType(uint64_t address) const {
+  return std::nullopt;
+}
+
+std::optional<VariableDecl>
+TypeProvider::GetDefaultVariableDecl(uint64_t address) const {
+  return std::nullopt;
+}
+
+
+std::optional<FunctionDecl>
+TypeProvider::TryGetFuntionTypeOrDefault(uint64_t address) const {
+  auto res = this->TryGetFunctionType(address);
+  if (res.has_value()) {
+    return res;
+  }
+
+  return this->GetDefaultFunctionType(address);
+}
+
+std::optional<CallableDecl> TypeProvider::TryGetCalledFunctionTypeOrDefault(
+    uint64_t function_address, const remill::Instruction &from_inst) const {
+  auto res = this->TryGetCalledFunctionType(function_address, from_inst);
+  if (res.has_value()) {
+    return res;
+  }
+
+  return this->GetDefaultFunctionType(function_address);
+}
+
+
+std::optional<CallableDecl> TypeProvider::TryGetCalledFunctionTypeOrDefault(
+    uint64_t function_address, const remill::Instruction &from_inst,
+    uint64_t to_address) const {
+  auto res =
+      this->TryGetCalledFunctionType(function_address, from_inst, to_address);
+  if (res.has_value()) {
+    return res;
+  }
+
+  return this->GetDefaultFunctionType(function_address);
+}
+
+std::optional<VariableDecl>
+TypeProvider::TryGetVariableTypeOrDefault(uint64_t address,
+                                          llvm::Type *hinted_value_type) const {
+  auto res = this->TryGetVariableType(address, hinted_value_type);
+  if (res.has_value()) {
+    return res;
+  }
+
+  return this->GetDefaultVariableDecl(address);
+}
+
+
 }  // namespace anvill


### PR DESCRIPTION
This PR allows for some fairly ugly cooperation between the type provider and value lifter to avoid committing to default types for pointers without entities. In many cases, we use anvill to lift portions of a binary without lifting all of the entities. In this case the type provider is used to hint about whether we have knowledge about what exists at a given variable. In the presence of type providers that just provide a default address for a type this doesnt work, so the type provider now hints that decl it's returning doesnt imply any knowledge about this specific EA