### PR TITLE
Uses Default Versions of Type Provider Functions when Needed

### DIFF
--- a/include/anvill/Providers.h
+++ b/include/anvill/Providers.h
@@ -41,13 +41,8 @@ class TypeProvider {
   virtual std::optional<VariableDecl>
   GetDefaultVariableDecl(uint64_t address) const;
 
-
   std::optional<FunctionDecl>
-  TryGetFuntionTypeOrDefault(uint64_t address) const;
-
-  std::optional<CallableDecl>
-  TryGetCalledFunctionTypeOrDefault(uint64_t function_address,
-                                    const remill::Instruction &from_inst) const;
+  TryGetFunctionTypeOrDefault(uint64_t address) const;
 
   std::optional<CallableDecl>
   TryGetCalledFunctionTypeOrDefault(uint64_t function_address,

--- a/lib/Lifters/ValueLifter.cpp
+++ b/lib/Lifters/ValueLifter.cpp
@@ -179,14 +179,8 @@ ValueLifterImpl::TryGetPointerForAddress(uint64_t ea,
     return unwrap_zero_indices(found_entity_at);
   }
 
-  auto maybe_decl = ent_lifter.type_provider->TryGetFunctionType(ea);
+  auto maybe_decl = ent_lifter.type_provider->TryGetFunctionTypeOrDefault(ea);
   if (maybe_decl) {
-    return GetFunctionPointer(*maybe_decl, ent_lifter);
-  }
-
-  auto maybe_default_decl =
-      ent_lifter.type_provider->TryGetFunctionTypeOrDefault(ea);
-  if (!hinted_type && maybe_default_decl) {
     return GetFunctionPointer(*maybe_decl, ent_lifter);
   }
 

--- a/lib/Lifters/ValueLifter.cpp
+++ b/lib/Lifters/ValueLifter.cpp
@@ -184,6 +184,12 @@ ValueLifterImpl::TryGetPointerForAddress(uint64_t ea,
     return GetFunctionPointer(*maybe_decl, ent_lifter);
   }
 
+  auto maybe_default_decl =
+      ent_lifter.type_provider->TryGetFunctionTypeOrDefault(ea);
+  if (!hinted_type && maybe_default_decl) {
+    return GetFunctionPointer(*maybe_decl, ent_lifter);
+  }
+
   // Try to create a `FunctionDecl` on-demand.
   if (hinted_type) {
     if (auto func_type =

--- a/lib/Providers/TypeProvider.cpp
+++ b/lib/Providers/TypeProvider.cpp
@@ -265,23 +265,13 @@ TypeProvider::GetDefaultVariableDecl(uint64_t address) const {
 
 
 std::optional<FunctionDecl>
-TypeProvider::TryGetFuntionTypeOrDefault(uint64_t address) const {
+TypeProvider::TryGetFunctionTypeOrDefault(uint64_t address) const {
   auto res = this->TryGetFunctionType(address);
   if (res.has_value()) {
     return res;
   }
 
   return this->GetDefaultFunctionType(address);
-}
-
-std::optional<CallableDecl> TypeProvider::TryGetCalledFunctionTypeOrDefault(
-    uint64_t function_address, const remill::Instruction &from_inst) const {
-  auto res = this->TryGetCalledFunctionType(function_address, from_inst);
-  if (res.has_value()) {
-    return res;
-  }
-
-  return this->GetDefaultFunctionType(function_address);
 }
 
 
@@ -294,7 +284,7 @@ std::optional<CallableDecl> TypeProvider::TryGetCalledFunctionTypeOrDefault(
     return res;
   }
 
-  return this->GetDefaultFunctionType(function_address);
+  return this->GetDefaultFunctionType(to_address);
 }
 
 std::optional<VariableDecl>


### PR DESCRIPTION
Uses the explicit default version of the type provider when defaults are acceptable.