### PR TITLE
Tracks Decoding Context for Instructions in Worklist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         image:
           - { name: 'ubuntu', tag: '20.04' }
         binja:
-          - {channel: 'headless', version: '3.0.3233'}
+          - {channel: 'headless', version: '3.1.3469'}
         llvm: [ '14' ]
         cxxcommon_version: [ 'v0.2.7' ]
 
@@ -775,7 +775,7 @@ jobs:
         llvm: ["14"]
         ubuntu: ["20.04"]
         binja:
-          - {channel: 'headless', version: '3.0.3233'}
+          - {channel: 'headless', version: '3.1.3469'}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         image:
           - { name: 'ubuntu', tag: '20.04' }
         binja:
-          - {channel: 'headless', version: '3.1.3469'}
+          - {channel: 'headless', version: '3.1.3479'}
         llvm: [ '14' ]
         cxxcommon_version: [ 'v0.2.7' ]
 
@@ -775,7 +775,7 @@ jobs:
         llvm: ["14"]
         ubuntu: ["20.04"]
         binja:
-          - {channel: 'headless', version: '3.1.3469'}
+          - {channel: 'headless', version: '3.1.3479'}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,9 +130,7 @@ RUN export BINJA_DECODE_KEY="${BINJA_DECODE_KEY}" && \
     cd /dependencies/binja_install && \
     if [[ "${BINJA_DECODE_KEY}" != "" ]]; then ./install_binja.sh && python3 switcher.py --version_string ${BINJA_VERSION} ${BINJA_CHANNEL}; fi
 
-RUN python3 --version
-
-RUN python3 -c "import binaryninja; print(binaryninja.core_version())"
+RUN apt-get install libdbus-1-3
 
 COPY scripts/docker-spec-entrypoint.sh /opt/trailofbits/docker-spec-entrypoint.sh
 ENTRYPOINT ["/opt/trailofbits/docker-spec-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,8 @@ RUN export BINJA_DECODE_KEY="${BINJA_DECODE_KEY}" && \
     cd /dependencies/binja_install && \
     if [[ "${BINJA_DECODE_KEY}" != "" ]]; then ./install_binja.sh && python3 switcher.py --version_string ${BINJA_VERSION} ${BINJA_CHANNEL}; fi
 
-RUN apt-get install libdbus-1-3
+# Keep this here to sanity check Binary Ninja API Installation & version
+RUN python3 --version && python3 -c "import binaryninja; print(binaryninja.core_version())"
 
 COPY scripts/docker-spec-entrypoint.sh /opt/trailofbits/docker-spec-entrypoint.sh
 ENTRYPOINT ["/opt/trailofbits/docker-spec-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,9 +130,9 @@ RUN export BINJA_DECODE_KEY="${BINJA_DECODE_KEY}" && \
     cd /dependencies/binja_install && \
     if [[ "${BINJA_DECODE_KEY}" != "" ]]; then ./install_binja.sh && python3 switcher.py --version_string ${BINJA_VERSION} ${BINJA_CHANNEL}; fi
 
-RUN python --version
+RUN python3 --version
 
-RUN python -c "import binaryninja; print(binaryninja.core_version())"
+RUN python3 -c "import binaryninja; print(binaryninja.core_version())"
 
 COPY scripts/docker-spec-entrypoint.sh /opt/trailofbits/docker-spec-entrypoint.sh
 ENTRYPOINT ["/opt/trailofbits/docker-spec-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG UBUNTU_VERSION
 ARG LIBRARIES
 ARG LLVM_VERSION
 RUN apt-get update && \
-    apt-get install -qqy --no-install-recommends curl unzip python3 python3-pip python3.8 python3.8-venv python3-setuptools xz-utils && \
+    apt-get install -qqy --no-install-recommends libdbus-1-3 curl unzip python3 python3-pip python3.8 python3.8-venv python3-setuptools xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,11 @@ RUN export BINJA_DECODE_KEY="${BINJA_DECODE_KEY}" && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /dependencies/binja_install && \
     if [[ "${BINJA_DECODE_KEY}" != "" ]]; then ./install_binja.sh && python3 switcher.py --version_string ${BINJA_VERSION} ${BINJA_CHANNEL}; fi
+
+RUN python --version
+
+RUN python -c "import binaryninja; print(binaryninja.core_version())"
+
 COPY scripts/docker-spec-entrypoint.sh /opt/trailofbits/docker-spec-entrypoint.sh
 ENTRYPOINT ["/opt/trailofbits/docker-spec-entrypoint.sh"]
 

--- a/ci/install_binja.sh
+++ b/ci/install_binja.sh
@@ -39,3 +39,4 @@ chmod +x "${EXTRACT_DIR}/binaryninja/scripts/linux-setup.sh"
 "${EXTRACT_DIR}/binaryninja/scripts/linux-setup.sh" -s -d -m -l &> /dev/null
 # virtual env, use -v; if not don't use it
 python3 "${EXTRACT_DIR}/binaryninja/scripts/install_api.py" ${VIRTUAL_ENV+"-v"}
+echo "API install done"

--- a/ci/switcher.py
+++ b/ci/switcher.py
@@ -29,6 +29,7 @@ def main():
         channel.update_to_latest()
     else:
         set_auto_updates_enabled(False)
+        print(channel.versions)
         for v in channel.versions:
             if args.version_string in v.version:
                 print("Updating...")

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -1055,8 +1055,8 @@ void FunctionLifter::VisitInstruction(
   // Even when something isn't supported or is invalid, we still lift
   // a call to a semantic, e.g.`INVALID_INSTRUCTION`, so we really want
   // to treat instruction lifting as an operation that can't fail.
-  (void) inst.GetLifter()->LiftIntoBlock(inst, block, state_ptr,
-                                         false /* is_delayed */);
+  std::ignore = inst.GetLifter()->LiftIntoBlock(inst, block, state_ptr,
+                                                false /* is_delayed */);
 
   // Figure out if we have to decode the subsequent instruction as a delayed
   // instruction.

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -158,7 +158,7 @@ FunctionLifter::FunctionLifter(const LifterOptions &options_)
       semantics_module(remill::LoadArchSemantics(options.arch)),
       llvm_context(semantics_module->getContext()),
       intrinsics(semantics_module.get()),
-      inst_lifter(options.arch->DefaultLifter(intrinsics)),
+      op_lifter(options.arch->DefaultLifter(intrinsics)),
       pc_reg(options.arch
                  ->RegisterByName(options.arch->ProgramCounterRegisterName())
                  ->EnclosingRegister()),
@@ -189,8 +189,9 @@ FunctionLifter::FunctionLifter(const LifterOptions &options_)
 // function drives a work list, where the first time we ask for the
 // instruction at `addr`, we enqueue a bit of work to decode and lift that
 // instruction.
-llvm::BasicBlock *FunctionLifter::GetOrCreateBlock(uint64_t from_addr,
-                                                   uint64_t to_addr) {
+llvm::BasicBlock *FunctionLifter::GetOrCreateBlock(
+    uint64_t from_addr, uint64_t to_addr,
+    const remill::DecodingContext::ContextMap &mapper) {
   auto &block = edge_to_dest_block[{from_addr, to_addr}];
   if (block) {
     return block;
@@ -204,25 +205,27 @@ llvm::BasicBlock *FunctionLifter::GetOrCreateBlock(uint64_t from_addr,
   //            `addr_to_block` so that we can observe self-tail-calls and
   //            lift them as such, rather than as jumps back into the first
   //            lifted block.
-  edge_work_list.emplace(to_addr, from_addr);
+  edge_work_list.emplace(to_addr, from_addr, mapper(to_addr));
 
   return block;
 }
 
-llvm::BasicBlock *
-FunctionLifter::GetOrCreateTargetBlock(const remill::Instruction &from_inst,
-                                       uint64_t to_addr) {
+llvm::BasicBlock *FunctionLifter::GetOrCreateTargetBlock(
+    const remill::Instruction &from_inst, uint64_t to_addr,
+    const remill::DecodingContext::ContextMap &mapper) {
   return GetOrCreateBlock(
       from_inst.pc,
-      options.control_flow_provider.GetRedirection(from_inst, to_addr));
+      options.control_flow_provider.GetRedirection(from_inst, to_addr), mapper);
 }
 
 // Try to decode an instruction at address `addr` into `*inst_out`. Returns
-// `true` is successful and `false` otherwise. `is_delayed` tells the decoder
+// the context map of the decoded instruction if successful and std::nullopt otherwise. `is_delayed` tells the decoder
 // whether or not the instruction being decoded is being decoded inside of a
 // delay slot of another instruction.
-bool FunctionLifter::DecodeInstructionInto(const uint64_t addr, bool is_delayed,
-                                           remill::Instruction *inst_out) {
+std::optional<remill::DecodingContext::ContextMap>
+FunctionLifter::DecodeInstructionInto(const uint64_t addr, bool is_delayed,
+                                      remill::Instruction *inst_out,
+                                      remill::DecodingContext context) {
   static const auto max_inst_size = options.arch->MaxInstructionSize();
   inst_out->Reset();
 
@@ -255,10 +258,11 @@ bool FunctionLifter::DecodeInstructionInto(const uint64_t addr, bool is_delayed,
   }
 
   if (is_delayed) {
-    return options.arch->DecodeDelayedInstruction(addr, inst_out->bytes,
-                                                  *inst_out);
+    return options.arch->DecodeDelayedInstruction(
+        addr, inst_out->bytes, *inst_out, std::move(context));
   } else {
-    return options.arch->DecodeInstruction(addr, inst_out->bytes, *inst_out);
+    return options.arch->DecodeInstruction(addr, inst_out->bytes, *inst_out,
+                                           std::move(context));
   }
 }
 
@@ -286,34 +290,39 @@ void FunctionLifter::VisitError(const remill::Instruction &inst,
 // Visit a normal instruction. Normal instructions have straight line control-
 // flow semantics, i.e. after executing the instruction, execution proceeds
 // to the next instruction (`inst.next_pc`).
-void FunctionLifter::VisitNormal(const remill::Instruction &inst,
-                                 llvm::BasicBlock *block) {
-  llvm::BranchInst::Create(GetOrCreateTargetBlock(inst, inst.next_pc), block);
+void FunctionLifter::VisitNormal(
+    const remill::Instruction &inst, llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
+  llvm::BranchInst::Create(GetOrCreateTargetBlock(inst, inst.next_pc, mapper),
+                           block);
 }
 
 // Visit a no-op instruction. These behave identically to normal instructions
 // from a control-flow perspective.
-void FunctionLifter::VisitNoOp(const remill::Instruction &inst,
-                               llvm::BasicBlock *block) {
-  VisitNormal(inst, block);
+void FunctionLifter::VisitNoOp(
+    const remill::Instruction &inst, llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
+  VisitNormal(inst, block, mapper);
 }
 
 // Visit a direct jump control-flow instruction. The target of the jump is
 // known at decode time, and the target address is available in
 // `inst.branch_taken_pc`. Execution thus needs to transfer to the instruction
 // (and thus `llvm::BasicBlock`) associated with `inst.branch_taken_pc`.
-void FunctionLifter::VisitDirectJump(const remill::Instruction &inst,
-                                     remill::Instruction *delayed_inst,
-                                     llvm::BasicBlock *block) {
+void FunctionLifter::VisitDirectJump(
+    const remill::Instruction &inst, remill::Instruction *delayed_inst,
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   VisitDelayedInstruction(inst, delayed_inst, block, true);
-  llvm::BranchInst::Create(GetOrCreateTargetBlock(inst, inst.branch_taken_pc),
-                           block);
+  llvm::BranchInst::Create(
+      GetOrCreateTargetBlock(inst, inst.branch_taken_pc, mapper), block);
 }
 
 // Visit an indirect jump that is a jump table.
 void FunctionLifter::DoSwitchBasedIndirectJump(
     const remill::Instruction &inst, llvm::BasicBlock *block,
-    const ControlFlowTargetList &target_list) {
+    const ControlFlowTargetList &target_list,
+    const remill::DecodingContext::ContextMap &mapper) {
 
   auto add_remill_jump{true};
   llvm::BasicBlock *current_bb = block;
@@ -333,7 +342,8 @@ void FunctionLifter::DoSwitchBasedIndirectJump(
     add_remill_jump = false;
 
     auto destination = *(target_list.target_addresses.begin());
-    llvm::BranchInst::Create(GetOrCreateTargetBlock(inst, destination), block);
+    llvm::BranchInst::Create(GetOrCreateTargetBlock(inst, destination, mapper),
+                             block);
 
     // We have multiple destinations. Handle this with a switch. If the target
     // list is not marked as complete, then we'll still add __remill_jump
@@ -359,7 +369,7 @@ void FunctionLifter::DoSwitchBasedIndirectJump(
     }
 
     // Create the parameters for the special anvill switch
-    auto pc = inst_lifter->LoadRegValue(
+    auto pc = this->op_lifter->LoadRegValue(
         block, state_ptr, options.arch->ProgramCounterRegisterName());
 
     std::vector<llvm::Value *> switch_parameters;
@@ -385,7 +395,7 @@ void FunctionLifter::DoSwitchBasedIndirectJump(
     auto dest_id{0u};
 
     for (auto dest : target_list.target_addresses) {
-      auto dest_block = GetOrCreateTargetBlock(inst, dest);
+      auto dest_block = GetOrCreateTargetBlock(inst, dest, mapper);
       auto dest_case = llvm::ConstantInt::get(address_type, dest_id++);
       switch_inst->addCase(dest_case, dest_block);
     }
@@ -409,9 +419,10 @@ void FunctionLifter::DoSwitchBasedIndirectJump(
 // not know a priori and our default mechanism for handling this is to perform
 // a tail-call to the `__remill_jump` function, whose role is to be a stand-in
 // something that enacts the effect of "transfer to target."
-void FunctionLifter::VisitIndirectJump(const remill::Instruction &inst,
-                                       remill::Instruction *delayed_inst,
-                                       llvm::BasicBlock *block) {
+void FunctionLifter::VisitIndirectJump(
+    const remill::Instruction &inst, remill::Instruction *delayed_inst,
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
 
   VisitDelayedInstruction(inst, delayed_inst, block, true);
 
@@ -431,7 +442,7 @@ void FunctionLifter::VisitIndirectJump(const remill::Instruction &inst,
   } else if (auto maybe_target_list =
                  options.control_flow_provider.TryGetControlFlowTargets(inst)) {
 
-    DoSwitchBasedIndirectJump(inst, block, *maybe_target_list);
+    DoSwitchBasedIndirectJump(inst, block, *maybe_target_list, mapper);
 
     // No good info; do an indirect jump.
   } else {
@@ -446,7 +457,8 @@ void FunctionLifter::VisitIndirectJump(const remill::Instruction &inst,
 // ARMv7 (AArch32) architecture, where many instructions are predicated.
 void FunctionLifter::VisitConditionalIndirectJump(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto lifted_func = block->getParent();
   const auto cond = remill::LoadBranchTaken(block);
   const auto taken_block =
@@ -478,7 +490,8 @@ void FunctionLifter::VisitConditionalIndirectJump(
   }
 
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   AnnotateInstruction(br1, pc_annotation_id, pc_annotation);
   AnnotateInstruction(br2, pc_annotation_id, pc_annotation);
@@ -503,7 +516,8 @@ void FunctionLifter::VisitFunctionReturn(const remill::Instruction &inst,
 // are possible on ARMv7 (AArch32).
 void FunctionLifter::VisitConditionalFunctionReturn(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto lifted_func = block->getParent();
   const auto cond = remill::LoadBranchTaken(block);
   const auto taken_block =
@@ -517,7 +531,8 @@ void FunctionLifter::VisitConditionalFunctionReturn(
       taken_block, intrinsics.function_return, intrinsics);
   VisitDelayedInstruction(inst, delayed_inst, not_taken_block, false);
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   MuteStateEscape(func_return);
   AnnotateInstruction(func_return, pc_annotation_id, pc_annotation);
@@ -633,12 +648,13 @@ void FunctionLifter::CallFunction(const remill::Instruction &inst,
 // at decode time, and its realized address is stored in
 // `inst.branch_taken_pc`. In practice, what we do in this situation is try
 // to call the lifted function function at the target address.
-void FunctionLifter::VisitDirectFunctionCall(const remill::Instruction &inst,
-                                             remill::Instruction *delayed_inst,
-                                             llvm::BasicBlock *block) {
+void FunctionLifter::VisitDirectFunctionCall(
+    const remill::Instruction &inst, remill::Instruction *delayed_inst,
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   VisitDelayedInstruction(inst, delayed_inst, block, true);
   CallFunction(inst, block, inst.branch_taken_pc);
-  VisitAfterFunctionCall(inst, block);
+  VisitAfterFunctionCall(inst, block, mapper);
 }
 
 // Visit a conditional direct function call control-flow instruction. The
@@ -649,7 +665,8 @@ void FunctionLifter::VisitDirectFunctionCall(const remill::Instruction &inst,
 // instruction to "tell us" if the condition is met.
 void FunctionLifter::VisitConditionalDirectFunctionCall(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto lifted_func = block->getParent();
   const auto cond = remill::LoadBranchTaken(block);
   const auto taken_block =
@@ -660,10 +677,11 @@ void FunctionLifter::VisitConditionalDirectFunctionCall(
       llvm::BranchInst::Create(taken_block, not_taken_block, cond, block);
   VisitDelayedInstruction(inst, delayed_inst, taken_block, true);
   CallFunction(inst, taken_block, inst.branch_taken_pc);
-  VisitAfterFunctionCall(inst, taken_block);
+  VisitAfterFunctionCall(inst, taken_block, mapper);
   VisitDelayedInstruction(inst, delayed_inst, not_taken_block, false);
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   AnnotateInstruction(br1, pc_annotation_id, pc_annotation);
   AnnotateInstruction(br2, pc_annotation_id, pc_annotation);
@@ -677,18 +695,20 @@ void FunctionLifter::VisitConditionalDirectFunctionCall(
 // as it presents itself in the binary.
 void FunctionLifter::VisitIndirectFunctionCall(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
 
   VisitDelayedInstruction(inst, delayed_inst, block, true);
   CallFunction(inst, block, std::nullopt);
-  VisitAfterFunctionCall(inst, block);
+  VisitAfterFunctionCall(inst, block, mapper);
 }
 
 // Visit a conditional indirect function call control-flow instruction.
 // This is a cross between conditional jumps and indirect function calls.
 void FunctionLifter::VisitConditionalIndirectFunctionCall(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto lifted_func = block->getParent();
   const auto cond = remill::LoadBranchTaken(block);
   const auto taken_block =
@@ -699,10 +719,11 @@ void FunctionLifter::VisitConditionalIndirectFunctionCall(
       llvm::BranchInst::Create(taken_block, not_taken_block, cond, block);
   VisitDelayedInstruction(inst, delayed_inst, taken_block, true);
   CallFunction(inst, taken_block, std::nullopt);
-  VisitAfterFunctionCall(inst, taken_block);
+  VisitAfterFunctionCall(inst, taken_block, mapper);
   VisitDelayedInstruction(inst, delayed_inst, not_taken_block, false);
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   AnnotateInstruction(br1, pc_annotation_id, pc_annotation);
   AnnotateInstruction(br2, pc_annotation_id, pc_annotation);
@@ -724,8 +745,8 @@ FunctionLifter::LoadFunctionReturnAddress(const remill::Instruction &inst,
 
   // The semantics for handling a call save the expected return program counter
   // into a local variable.
-  auto ret_pc = inst_lifter->LoadRegValue(block, state_ptr,
-                                          remill::kReturnPCVariableName);
+  auto ret_pc = this->op_lifter->LoadRegValue(block, state_ptr,
+                                              remill::kReturnPCVariableName);
   if (!is_sparc) {
     return {pc, ret_pc};
   }
@@ -801,14 +822,16 @@ FunctionLifter::LoadFunctionReturnAddress(const remill::Instruction &inst,
 // Enact relevant control-flow changes after a function call. This figures
 // out the return address targeted by the callee and links it into the
 // control-flow graph.
-void FunctionLifter::VisitAfterFunctionCall(const remill::Instruction &inst,
-                                            llvm::BasicBlock *block) {
+void FunctionLifter::VisitAfterFunctionCall(
+    const remill::Instruction &inst, llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto [ret_pc, ret_pc_val] = LoadFunctionReturnAddress(inst, block);
 
   llvm::IRBuilder<> ir(block);
   auto update_pc = ir.CreateStore(ret_pc_val, pc_reg_ref, false);
   auto update_next_pc = ir.CreateStore(ret_pc_val, next_pc_reg_ref, false);
-  auto branch_to_next_pc = ir.CreateBr(GetOrCreateTargetBlock(inst, ret_pc));
+  auto branch_to_next_pc =
+      ir.CreateBr(GetOrCreateTargetBlock(inst, ret_pc, mapper));
 
   AnnotateInstruction(update_pc, pc_annotation_id, pc_annotation);
   AnnotateInstruction(update_next_pc, pc_annotation_id, pc_annotation);
@@ -821,9 +844,10 @@ void FunctionLifter::VisitAfterFunctionCall(const remill::Instruction &inst,
 // Here we need to orchestrate the two-way control-flow, as well as the
 // possible execution of a delayed instruction on either or both paths,
 // depending on the presence/absence of delay slot annulment bits.
-void FunctionLifter::VisitConditionalBranch(const remill::Instruction &inst,
-                                            remill::Instruction *delayed_inst,
-                                            llvm::BasicBlock *block) {
+void FunctionLifter::VisitConditionalBranch(
+    const remill::Instruction &inst, remill::Instruction *delayed_inst,
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   std::stringstream taken_ss;
   taken_ss << "inst_" << std::hex << inst.pc << "_taken_"
            << inst.branch_taken_pc;
@@ -843,9 +867,10 @@ void FunctionLifter::VisitConditionalBranch(const remill::Instruction &inst,
   VisitDelayedInstruction(inst, delayed_inst, taken_block, true);
   VisitDelayedInstruction(inst, delayed_inst, not_taken_block, false);
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_taken_pc), taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_taken_pc, mapper), taken_block);
   auto br3 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   AnnotateInstruction(br1, pc_annotation_id, pc_annotation);
   AnnotateInstruction(br2, pc_annotation_id, pc_annotation);
@@ -867,7 +892,8 @@ void FunctionLifter::VisitAsyncHyperCall(const remill::Instruction &inst,
 // local control-flow transfers, e.g. `bound` on x86.
 void FunctionLifter::VisitConditionalAsyncHyperCall(
     const remill::Instruction &inst, remill::Instruction *delayed_inst,
-    llvm::BasicBlock *block) {
+    llvm::BasicBlock *block,
+    const remill::DecodingContext::ContextMap &mapper) {
   const auto lifted_func = block->getParent();
   const auto cond = remill::LoadBranchTaken(block);
   const auto taken_block =
@@ -883,7 +909,8 @@ void FunctionLifter::VisitConditionalAsyncHyperCall(
       taken_block, intrinsics.async_hyper_call, intrinsics);
 
   auto br2 = llvm::BranchInst::Create(
-      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc), not_taken_block);
+      GetOrCreateTargetBlock(inst, inst.branch_not_taken_pc, mapper),
+      not_taken_block);
 
   AnnotateInstruction(br1, pc_annotation_id, pc_annotation);
   AnnotateInstruction(br2, pc_annotation_id, pc_annotation);
@@ -904,7 +931,7 @@ void FunctionLifter::VisitDelayedInstruction(const remill::Instruction &inst,
                           inst, *delayed_inst, on_taken_path)) {
     const auto prev_pc_annotation = pc_annotation;
     pc_annotation = GetPCAnnotation(delayed_inst->pc);
-    inst_lifter->LiftIntoBlock(*delayed_inst, block, state_ptr, true);
+    inst.GetLifter()->LiftIntoBlock(*delayed_inst, block, state_ptr, true);
     AnnotateInstructions(block, pc_annotation_id, pc_annotation);
     pc_annotation = prev_pc_annotation;
   }
@@ -943,7 +970,8 @@ void FunctionLifter::InstrumentDataflowProvenance(llvm::BasicBlock *block) {
   args.push_back(llvm::ConstantInt::get(pc_reg_type, curr_inst->pc));
   options.arch->ForEachRegister([&](const remill::Register *reg) {
     if (reg != pc_reg && reg != sp_reg && reg->EnclosingRegister() == reg) {
-      args.push_back(inst_lifter->LoadRegValue(block, state_ptr, reg->name));
+      args.push_back(
+          this->op_lifter->LoadRegValue(block, state_ptr, reg->name));
     }
   });
 
@@ -986,8 +1014,9 @@ void FunctionLifter::InstrumentCallBreakpointFunction(llvm::BasicBlock *block) {
   llvm::Value *args[] = {
       new llvm::LoadInst(mem_ptr_type, mem_ptr_ref, llvm::Twine::createNull(),
                          block),
-      inst_lifter->LoadRegValue(block, state_ptr, remill::kPCVariableName),
-      inst_lifter->LoadRegValue(block, state_ptr, remill::kNextPCVariableName)};
+      this->op_lifter->LoadRegValue(block, state_ptr, remill::kPCVariableName),
+      this->op_lifter->LoadRegValue(block, state_ptr,
+                                    remill::kNextPCVariableName)};
   llvm::IRBuilder<> ir(block);
   ir.CreateCall(func, args);
 }
@@ -995,8 +1024,10 @@ void FunctionLifter::InstrumentCallBreakpointFunction(llvm::BasicBlock *block) {
 // Visit an instruction, and lift it into a basic block. Then, based off of
 // the category of the instruction, invoke one of the category-specific
 // lifters to enact a change in control-flow.
-void FunctionLifter::VisitInstruction(remill::Instruction &inst,
-                                      llvm::BasicBlock *block) {
+void FunctionLifter::VisitInstruction(
+    remill::Instruction &inst, llvm::BasicBlock *block,
+    remill::DecodingContext prev_insn_context,
+    const remill::DecodingContext::ContextMap &mapper) {
   curr_inst = &inst;
 
   // TODO(pag): Consider emitting calls to the `llvm.pcmarker` intrinsic. Figure
@@ -1023,15 +1054,15 @@ void FunctionLifter::VisitInstruction(remill::Instruction &inst,
   // Even when something isn't supported or is invalid, we still lift
   // a call to a semantic, e.g.`INVALID_INSTRUCTION`, so we really want
   // to treat instruction lifting as an operation that can't fail.
-  (void) inst_lifter->LiftIntoBlock(inst, block, state_ptr,
-                                    false /* is_delayed */);
+  (void) inst.GetLifter()->LiftIntoBlock(inst, block, state_ptr,
+                                         false /* is_delayed */);
 
   // Figure out if we have to decode the subsequent instruction as a delayed
   // instruction.
   if (options.arch->MayHaveDelaySlot(inst)) {
     delayed_inst = new (&delayed_inst_storage) remill::Instruction;
     if (!DecodeInstructionInto(inst.delayed_pc, true /* is_delayed */,
-                               delayed_inst)) {
+                               delayed_inst, prev_insn_context)) {
       LOG(ERROR) << "Unable to decode or use delayed instruction at "
                  << std::hex << inst.delayed_pc << std::dec << " of "
                  << inst.Serialize();
@@ -1045,7 +1076,6 @@ void FunctionLifter::VisitInstruction(remill::Instruction &inst,
   AnnotateInstructions(block, pc_annotation_id, pc_annotation);
 
   switch (inst.category) {
-
     // Invalid means failed to decode.
     case remill::Instruction::kCategoryInvalid:
       VisitInvalid(inst, block);
@@ -1056,43 +1086,47 @@ void FunctionLifter::VisitInstruction(remill::Instruction &inst,
     case remill::Instruction::kCategoryError:
       VisitError(inst, delayed_inst, block);
       break;
-    case remill::Instruction::kCategoryNormal: VisitNormal(inst, block); break;
-    case remill::Instruction::kCategoryNoOp: VisitNoOp(inst, block); break;
+    case remill::Instruction::kCategoryNormal:
+      VisitNormal(inst, block, mapper);
+      break;
+    case remill::Instruction::kCategoryNoOp:
+      VisitNoOp(inst, block, mapper);
+      break;
     case remill::Instruction::kCategoryDirectJump:
-      VisitDirectJump(inst, delayed_inst, block);
+      VisitDirectJump(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryIndirectJump:
-      VisitIndirectJump(inst, delayed_inst, block);
+      VisitIndirectJump(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryConditionalIndirectJump:
-      VisitConditionalIndirectJump(inst, delayed_inst, block);
+      VisitConditionalIndirectJump(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryFunctionReturn:
       VisitFunctionReturn(inst, delayed_inst, block);
       break;
     case remill::Instruction::kCategoryConditionalFunctionReturn:
-      VisitConditionalFunctionReturn(inst, delayed_inst, block);
+      VisitConditionalFunctionReturn(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryDirectFunctionCall:
-      VisitDirectFunctionCall(inst, delayed_inst, block);
+      VisitDirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryConditionalDirectFunctionCall:
-      VisitDirectFunctionCall(inst, delayed_inst, block);
+      VisitDirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryIndirectFunctionCall:
-      VisitIndirectFunctionCall(inst, delayed_inst, block);
+      VisitIndirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryConditionalIndirectFunctionCall:
-      VisitConditionalIndirectFunctionCall(inst, delayed_inst, block);
+      VisitConditionalIndirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryConditionalBranch:
-      VisitConditionalBranch(inst, delayed_inst, block);
+      VisitConditionalBranch(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryAsyncHyperCall:
       VisitAsyncHyperCall(inst, delayed_inst, block);
       break;
     case remill::Instruction::kCategoryConditionalAsyncHyperCall:
-      VisitConditionalAsyncHyperCall(inst, delayed_inst, block);
+      VisitConditionalAsyncHyperCall(inst, delayed_inst, block, mapper);
       break;
   }
 
@@ -1135,7 +1169,8 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
 
   // Recursively decode and lift all instructions that we come across.
   while (!edge_work_list.empty()) {
-    auto [inst_addr, from_addr] = *(edge_work_list.begin());
+    auto [inst_addr, from_addr, insn_context] = *(edge_work_list.begin());
+
     edge_work_list.erase(edge_work_list.begin());
 
     llvm::BasicBlock *const block = edge_to_dest_block[{from_addr, inst_addr}];
@@ -1197,7 +1232,9 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
     }
 
     // Decode.
-    if (!DecodeInstructionInto(inst_addr, false /* is_delayed */, &inst)) {
+    auto next_context = DecodeInstructionInto(inst_addr, false /* is_delayed */,
+                                              &inst, insn_context);
+    if (!next_context) {
       if (inst_addr == func_address) {
         inst.pc = inst_addr;
         inst.arch_name = options.arch->arch_name;
@@ -1207,8 +1244,11 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
         // Failed to decode the first instruction of the function, but we can
         // possibly recover via a tail-call to a redirection address!
         if (inst_addr != func_address) {
+          // TODO(Ian): is this context right?
+          auto cont =
+              remill::DecodingContext::UniformContextMapping(insn_context);
           auto br = llvm::BranchInst::Create(
-              GetOrCreateBlock(func_address, inst_addr), block);
+              GetOrCreateBlock(func_address, inst_addr, cont), block);
           AnnotateInstruction(br, pc_annotation_id, pc_annotation);
           continue;
         }
@@ -1231,7 +1271,6 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
       AnnotateInstruction(call, pc_annotation_id, pc_annotation);
       MuteStateEscape(call);
       continue;
-
     } else {
       if (inst_addr == func_address) {
         inst_addr =
@@ -1242,13 +1281,13 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
         // that leak the `State` structure.
         if (inst_addr != func_address) {
           auto br = llvm::BranchInst::Create(
-              GetOrCreateBlock(func_address, inst_addr), block);
+              GetOrCreateBlock(func_address, inst_addr, *next_context), block);
           AnnotateInstruction(br, pc_annotation_id, pc_annotation);
           continue;
         }
       }
 
-      VisitInstruction(inst, block);
+      VisitInstruction(inst, block, insn_context, *next_context);
     }
   }
 }
@@ -1641,7 +1680,6 @@ llvm::Function *FunctionLifter::LiftFunction(const FunctionDecl &decl) {
   edge_work_list.clear();
   edge_to_dest_block.clear();
   addr_to_block.clear();
-  inst_lifter->ClearCache();
   curr_decl = &decl;
   curr_inst = nullptr;
   state_ptr = nullptr;
@@ -1692,13 +1730,15 @@ llvm::Function *FunctionLifter::LiftFunction(const FunctionDecl &decl) {
   const auto pc = remill::NthArgument(lifted_func, remill::kPCArgNum);
   const auto entry_block = &(lifted_func->getEntryBlock());
   pc_reg_ref =
-      inst_lifter->LoadRegAddress(entry_block, state_ptr, pc_reg->name).first;
+      this->op_lifter->LoadRegAddress(entry_block, state_ptr, pc_reg->name)
+          .first;
   next_pc_reg_ref =
-      inst_lifter
+      this->op_lifter
           ->LoadRegAddress(entry_block, state_ptr, remill::kNextPCVariableName)
           .first;
   sp_reg_ref =
-      inst_lifter->LoadRegAddress(entry_block, state_ptr, sp_reg->name).first;
+      this->op_lifter->LoadRegAddress(entry_block, state_ptr, sp_reg->name)
+          .first;
 
   mem_ptr_ref = remill::LoadMemoryPointerRef(entry_block);
 
@@ -1719,7 +1759,12 @@ llvm::Function *FunctionLifter::LiftFunction(const FunctionDecl &decl) {
   //
   // TODO: This could be a thunk, that we are maybe lifting on purpose.
   //       How should control flow redirection behave in this case?
-  ir.CreateBr(GetOrCreateBlock(0u, func_address));
+
+  // TODO(Ian): for a thumb vs arm function we need to figure out how to setup the correct initial context,
+  // maybe the spec should have a section (Context reg assignments or something), where we apply those assingments to a defautl initial context
+  auto default_mapping = remill::DecodingContext::UniformContextMapping(
+      options.arch->CreateInitialContext());
+  ir.CreateBr(GetOrCreateBlock(0u, func_address, default_mapping));
 
   AnnotateInstructions(entry_block, pc_annotation_id,
                        GetPCAnnotation(func_address));

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -1112,7 +1112,7 @@ void FunctionLifter::VisitInstruction(
       VisitDirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryConditionalDirectFunctionCall:
-      VisitDirectFunctionCall(inst, delayed_inst, block, mapper);
+      VisitConditionalDirectFunctionCall(inst, delayed_inst, block, mapper);
       break;
     case remill::Instruction::kCategoryIndirectFunctionCall:
       VisitIndirectFunctionCall(inst, delayed_inst, block, mapper);

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -217,7 +217,7 @@ llvm::BasicBlock *FunctionLifter::GetOrCreateBlock(
   //            lift them as such, rather than as jumps back into the first
   //            lifted block.
   edge_work_list.emplace(to_addr, from_addr);
-  this->decoding_contexts.emplace(std::make_tuple(to_addr, from_addr),
+  this->decoding_contexts.emplace(std::make_pair(to_addr, from_addr),
                                   mapper(to_addr));
   return block;
 }

--- a/lib/Lifters/FunctionLifter.h
+++ b/lib/Lifters/FunctionLifter.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 namespace llvm {
 class Constant;

--- a/lib/Lifters/FunctionLifter.h
+++ b/lib/Lifters/FunctionLifter.h
@@ -12,6 +12,8 @@
 #include <anvill/Lifters.h>
 #include <anvill/Type.h>
 #include <llvm/IR/CallingConv.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instruction.h>
 #include <remill/Arch/Context.h>
 #include <remill/BC/InstructionLifter.h>
 #include <remill/BC/IntrinsicTable.h>
@@ -183,6 +185,12 @@ class FunctionLifter {
   // Declare the function decl `decl` and return an `llvm::Function *`. The
   // returned function is a "high-level" function.
   llvm::Function *GetOrDeclareFunction(const FunctionDecl &decl);
+
+
+  llvm::BranchInst *
+  BranchToInst(uint64_t from_addr, uint64_t to_addr,
+               const remill::DecodingContext::ContextMap &mapper,
+               llvm::BasicBlock *from_block);
 
   // Helper to get the basic block to contain the instruction at `addr`. This
   // function drives a work list, where the first time we ask for the

--- a/lib/Lifters/FunctionLifter.h
+++ b/lib/Lifters/FunctionLifter.h
@@ -158,8 +158,11 @@ class FunctionLifter {
   // NOTE(pag): The destination PC of the edge comes first in the work list so
   //            that the ordering of the `std::set` processes the instructions
   //            roughly in order.
-  std::set<std::tuple<uint64_t, uint64_t, remill::DecodingContext>>
-      edge_work_list;
+  std::set<std::tuple<uint64_t, uint64_t>> edge_work_list;
+
+  // We assume decoding contexts are constant per edge. If this is not the case a lot of things wont work out
+  std::map<std::pair<uint64_t, uint64_t>, remill::DecodingContext>
+      decoding_contexts;
 
   // Maps control flow edges `(from_pc -> to_pc)` to the basic block associated
   // with `to_pc`.


### PR DESCRIPTION
This PR gets anvill building against remill https://github.com/lifting-bits/remill/pull/617 and should encompass most of the anvill side changes to support mixed mode. The last thing to work out here is how we want to specify building the initial context per function ie. for a thumb labeled function we need an initial context with TM set to 1. One possibility is to have a context assignment list in the spec for functions 