### PR TITLE
Fix 310

### DIFF
--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -158,7 +158,6 @@ FunctionLifter::FunctionLifter(const LifterOptions &options_)
       semantics_module(remill::LoadArchSemantics(options.arch)),
       llvm_context(semantics_module->getContext()),
       intrinsics(semantics_module.get()),
-      //inst_lifter(options.arch->DefaultLifter(intrinsics)),
       inst_lifter( std::make_shared< remill::InstructionLifter >( options.arch, intrinsics ) ),
       context( options.arch->CreateInitialContext() ),
       pc_reg(options.arch

--- a/lib/Lifters/FunctionLifter.h
+++ b/lib/Lifters/FunctionLifter.h
@@ -15,6 +15,8 @@
 #include <remill/BC/InstructionLifter.h>
 #include <remill/BC/IntrinsicTable.h>
 
+#include <remill/Arch/Context.h>
+
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -84,6 +86,10 @@ class FunctionLifter {
 
   // TODO(pag): Consider passing in the `InstructionLifter` via `LifterOptions`?
   remill::InstructionLifter::LifterPtr inst_lifter;
+
+  // Decoding context
+  //
+  remill::DecodingContext context;
 
   // Specification counter and stack pointer registers.
   const remill::Register *const pc_reg;


### PR DESCRIPTION
Hello,

I also came across the compilation bug referenced by this issue [Build fails with latest Remill #310](https://github.com/lifting-bits/anvill/issues/310).

The pull request implements the new `remill::InstructionLifter` constructor prototype as well as handling of the new return type`std::optional< DecodingResult >` in `DecodeInstruction`and `DecodeDelayedInstruction`. I don't know well remill and anvil yet so I went the dumb way to handling the decoding result. If `DecodeInstructionInto` needs to return the new type as well I can update the PR.

Kind regards,
Midi