### PR TITLE
check for the string arm64 in addition to aarch64

### DIFF
--- a/cmake/vcpkg_helper.cmake
+++ b/cmake/vcpkg_helper.cmake
@@ -31,7 +31,7 @@ if (NOT DEFINED VCPKG_TARGET_TRIPLET)
   else()
     message(WARNING "No detection of architecture for this platform. Assuming x64")
   endif()
-  if (_SYSTEM_ARCH MATCHES "^[Aa][Aa][Rr][Cc][Hh]64$")
+  if (_SYSTEM_ARCH MATCHES "^[Aa][Aa][Rr][Cc][Hh]64$" OR _SYSTEM_ARCH MATCHES "^[Aa][Rr][Mm]64$")
     set(_project_arch "arm64")
   endif()
 


### PR DESCRIPTION
m1 macs for some reason use arm64 instead of aarch64 on linux