### PR TITLE
Ian/simplify redirections

### DIFF
--- a/include/anvill/Providers.h
+++ b/include/anvill/Providers.h
@@ -330,10 +330,7 @@ class ControlFlowProvider {
  public:
   virtual ~ControlFlowProvider(void) = default;
 
-  // Returns a possible redirection for the given target. If there is no
-  // redirection then `address` should be returned.
-  virtual std::uint64_t GetRedirection(const remill::Instruction &from_inst,
-                                       std::uint64_t to_address) const = 0;
+  virtual std::uint64_t GetCallRedirection(uint64_t from_addres) const = 0;
 
   // Returns a list of targets reachable from the given address
   virtual std::optional<ControlFlowTargetList>
@@ -354,8 +351,8 @@ class NullControlFlowProvider : public ControlFlowProvider {
  public:
   virtual ~NullControlFlowProvider(void) = default;
 
-  std::uint64_t GetRedirection(const remill::Instruction &,
-                               std::uint64_t address) const override;
+
+  std::uint64_t GetCallRedirection(uint64_t from_addres) const override;
 
   std::optional<ControlFlowTargetList>
   TryGetControlFlowTargets(const remill::Instruction &) const override;
@@ -370,8 +367,7 @@ class SpecificationControlFlowProvider : public anvill::ControlFlowProvider {
 
   explicit SpecificationControlFlowProvider(const Specification &spec);
 
-  std::uint64_t GetRedirection(const remill::Instruction &from_inst,
-                               std::uint64_t address) const final;
+  std::uint64_t GetCallRedirection(uint64_t from_addres) const override;
 
   std::optional<anvill::ControlFlowTargetList>
   TryGetControlFlowTargets(const remill::Instruction &from_inst) const final;

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -844,9 +844,7 @@ void FunctionLifter::VisitAfterFunctionCall(
     auto tail = remill::AddTerminatingTailCall(
         ir.GetInsertBlock(), intrinsics.error, this->intrinsics);
     AnnotateInstruction(tail, pc_annotation_id, pc_annotation);
-    auto ret = ir.CreateRet(tail);
     AnnotateInstruction(tail, pc_annotation_id, pc_annotation);
-    AnnotateInstruction(ret, pc_annotation_id, pc_annotation);
   }
 }
 
@@ -1640,6 +1638,15 @@ void FunctionLifter::RecursivelyInlineLiftedFunctionIntoNativeFunction(void) {
   }
 
   // Initialize cleanup optimizations
+
+
+  if (llvm::verifyFunction(*native_func, &llvm::errs())) {
+
+    LOG(FATAL) << "Function verification failed: "
+               << native_func->getName().str() << " "
+               << remill::LLVMThingToString(native_func->getType());
+  }
+
   llvm::legacy::FunctionPassManager fpm(semantics_module.get());
   fpm.add(llvm::createCFGSimplificationPass());
   fpm.add(llvm::createPromoteMemoryToRegisterPass());

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -1214,16 +1214,15 @@ void FunctionLifter::VisitInstructions(uint64_t address) {
           block, options.program_counter_init_procedure(ir, pc_reg, redir_addr),
           std::move(maybe_decl.value()));
 
-      llvm::Instruction *ret;
+
       if (is_noreturn) {
         auto tail = remill::AddTerminatingTailCall(
             ir.GetInsertBlock(), intrinsics.error, this->intrinsics);
         AnnotateInstruction(tail, pc_annotation_id, pc_annotation);
-        ret = ir.CreateRet(tail);
       } else {
-        ret = ir.CreateRet(new_mem_ptr);
+        llvm::Instruction *ret = ir.CreateRet(new_mem_ptr);
+        AnnotateInstruction(ret, pc_annotation_id, pc_annotation);
       }
-      AnnotateInstruction(ret, pc_annotation_id, pc_annotation);
       continue;
     }
 

--- a/lib/Lifters/FunctionLifter.h
+++ b/lib/Lifters/FunctionLifter.h
@@ -309,8 +309,7 @@ class FunctionLifter {
   // thunks
   std::optional<CallableDecl>
   TryGetTargetFunctionType(const remill::Instruction &inst,
-                           std::uint64_t address,
-                           std::uint64_t redirected_address);
+                           std::uint64_t address);
 
   // Visit a direct function call control-flow instruction. The target is known
   // at decode time, and its realized address is stored in
@@ -368,11 +367,10 @@ class FunctionLifter {
   // Enact relevant control-flow changed after a function call. This figures
   // out the return address targeted by the callee and links it into the
   // control-flow graph.
-  void
-  VisitAfterFunctionCall(const remill::Instruction &inst,
-                         llvm::BasicBlock *block,
-                         const remill::DecodingContext::ContextMap &mapper,
-                         bool can_return);
+  void VisitAfterFunctionCall(const remill::Instruction &inst,
+                              llvm::BasicBlock *block,
+                              const remill::DecodingContext::ContextMap &mapper,
+                              bool can_return);
 
   // Visit a conditional control-flow branch. Both the taken and not taken
   // targets are known by the decoder and their addresses are available in

--- a/lib/Providers/ControlFlowProvider.cpp
+++ b/lib/Providers/ControlFlowProvider.cpp
@@ -7,20 +7,20 @@
  */
 
 #include <anvill/Providers.h>
-
 #include <remill/Arch/Instruction.h>
 
 #include "Specification.h"
 
 namespace anvill {
 
-std::uint64_t NullControlFlowProvider::GetRedirection(
-    const remill::Instruction &, std::uint64_t address) const {
-  return address;
+std::uint64_t
+NullControlFlowProvider::GetCallRedirection(std::uint64_t target) const {
+  return target;
 }
 
 std::optional<ControlFlowTargetList>
-NullControlFlowProvider::TryGetControlFlowTargets(const remill::Instruction &) const {
+NullControlFlowProvider::TryGetControlFlowTargets(
+    const remill::Instruction &) const {
   return std::nullopt;
 }
 
@@ -29,15 +29,15 @@ SpecificationControlFlowProvider::~SpecificationControlFlowProvider(void) {}
 
 SpecificationControlFlowProvider::SpecificationControlFlowProvider(
     const Specification &spec)
-      : impl(spec.impl) {}
+    : impl(spec.impl) {}
 
-std::uint64_t SpecificationControlFlowProvider::GetRedirection(
-    const remill::Instruction &inst, std::uint64_t address) const {
-  auto it = impl->redirections.find(inst.pc);
+std::uint64_t SpecificationControlFlowProvider::GetCallRedirection(
+    std::uint64_t target) const {
+  auto it = impl->redirections.find(target);
   if (it != impl->redirections.end()) {
     return it->second;
   } else {
-    return address;
+    return target;
   }
 }
 


### PR DESCRIPTION
This PR simplifies redirections to only redirect targets, rather than instruction/call/jump sites. This narrows redirections role to only handle thunks. calls inside of a thunk when lifting can just behandled by treating the jump as a tail call naturally. This PR also cherry-picks a fix to avoid adding returns after certain errors