### PR TITLE
Remove cruft

### DIFF
--- a/python/anvill/__main__.py
+++ b/python/anvill/__main__.py
@@ -134,7 +134,7 @@ def main():
                     DEBUG(f"Adding {name}")
                     p.add_symbol(ea, f"{name}")
                 else:
-                    # all other symbols postfixed with address of function
+                    # all other symbols postfixed with address of symbol
                     DEBUG(f"Adding symbol {name}_{ea:x}")
                     p.add_symbol(ea, f"{name}_{ea:x}")
 

--- a/python/anvill/__main__.py
+++ b/python/anvill/__main__.py
@@ -54,6 +54,8 @@ def main():
 
     arg_parser.add_argument("--entrypoint", type=str, help="only specify functions from entrypoint")
 
+    arg_parser.add_argument("--ignore_no_refs", action="store_true", default=False, help="ignore globals with no references")
+
     args = arg_parser.parse_args()
 
     # Configure logger
@@ -161,7 +163,7 @@ def main():
         else:
             try:
                 DEBUG(f"Found variable at: {ea:x}")
-                p.add_variable_definition(ea, True)
+                p.add_variable_definition(ea, True, args.ignore_no_refs)
             except:
                 ERROR(f"Error when trying to add variable {ea:x}: {traceback.format_exc()}")
 

--- a/python/anvill/__main__.py
+++ b/python/anvill/__main__.py
@@ -130,7 +130,10 @@ def main():
                     break
             else:
                 # main use original symbol name
-                if name == "main":
+                # Global and Weak bindings use original name
+                if name == "main" or \
+                   s.binding == bn.SymbolBinding.GlobalBinding or \
+                   s.binding == bn.SymbolBinding.WeakBinding:
                     DEBUG(f"Adding {name}")
                     p.add_symbol(ea, f"{name}")
                 else:

--- a/python/anvill/binja/bnvariable.py
+++ b/python/anvill/binja/bnvariable.py
@@ -18,7 +18,7 @@ class BNVariable(Variable):
         super(BNVariable, self).__init__(arch, address, type_)
         self._bn_var = bn_var
 
-    def visit(self, program, is_definition, add_refs_as_defs):
+    def visit(self, program, is_definition, add_refs_as_defs, ignore_no_refs):
         if not is_definition:
             return
 
@@ -44,9 +44,10 @@ class BNVariable(Variable):
                 continue
 
             # ignore data variables with no references
-            var = bv.data_vars.get(ea)
-            if var is not None and next(var.code_refs, None) is None and next(var.data_refs, None) is None:
-                continue
+            if ignore_no_refs:
+                var = bv.data_vars.get(ea)
+                if var is not None and next(var.code_refs, None) is None and next(var.data_refs, None) is None:
+                    continue
 
             #NOTE(artem): This is a workaround for binary ninja's fake
             # .externs section, which is (correctly) mapped as

--- a/python/anvill/binja/bnvariable.py
+++ b/python/anvill/binja/bnvariable.py
@@ -39,8 +39,13 @@ class BNVariable(Variable):
             br.seek(ea)
             seg = bv.get_segment_at(ea)
             # _elf_header is getting recovered as variable
-            # get_segment_at(...) returns None for elf_header
-            if seg is None:
+            # ignore null pointer reference
+            if ea == 0:
+                continue
+
+            # ignore data variables with no references
+            var = bv.data_vars.get(ea)
+            if var is not None and next(var.code_refs, None) is None and next(var.data_refs, None) is None:
                 continue
 
             #NOTE(artem): This is a workaround for binary ninja's fake

--- a/python/anvill/ida/idavariable.py
+++ b/python/anvill/ida/idavariable.py
@@ -21,7 +21,7 @@ class IDAVariable(Variable):
         super(IDAVariable, self).__init__(arch, address, type_)
         self._ida_seg = ida_seg
 
-    def visit(self, program, is_definition, add_refs_as_defs):
+    def visit(self, program, is_definition, add_refs_as_defs, ignore_no_refs):
         seg_ref = [None]
         seg = find_segment_containing_ea(self.address(), seg_ref)
         if seg and is_imported_table_seg(seg):

--- a/python/anvill/var.py
+++ b/python/anvill/var.py
@@ -29,7 +29,7 @@ class Variable(object):
         return self._type
 
     @abstractmethod
-    def visit(self, program: "Specification", is_definition: bool, add_refs_as_defs: bool):
+    def visit(self, program: "Specification", is_definition: bool, add_refs_as_defs: bool, ignore_no_refs: bool):
         ...
 
     def proto(self) -> Dict[str, Any]:


### PR DESCRIPTION
 * Ignore variables with no references
   * no real point in lifting those
 * Append address to name (with the exception of externs/main) to avoid naming conflicts