### PR TITLE
Adds a control flow simplification pass to support idiomatic block gotos

### DIFF
--- a/bin/Decompile/Main.cpp
+++ b/bin/Decompile/Main.cpp
@@ -45,6 +45,8 @@ DEFINE_bool(add_breakpoints, false,
 DEFINE_bool(add_names, false, "Try to apply symbol names to lifted entities.");
 DEFINE_bool(disable_opt, false, "Dont apply optimization passes");
 DEFINE_bool(llvm_debug, false, "Enable LLVM debug flag");
+DEFINE_bool(remove_next_pc_assignments, false,
+            "Enables remove next pc assignment pass");
 
 DEFINE_string(
     default_callable_spec, "",
@@ -171,6 +173,9 @@ int main(int argc, char *argv[]) {
   // points.
   options.stack_frame_recovery_options.stack_offset_metadata_name =
       "stack_offset";
+
+  options.should_remove_assignments_to_next_pc =
+      FLAGS_remove_next_pc_assignments;
 
   anvill::EntityLifter lifter(options);
 

--- a/include/anvill/ABI.h
+++ b/include/anvill/ABI.h
@@ -88,4 +88,8 @@ extern const std::string kBasicBlockMetadata;
 /// Intrinsic that acts like a return instruction but leaves both the basic block and the parent function.
 extern const std::string kAnvillBasicBlockReturn;
 
+
+// Instrinsic that acts as a goto to an address
+extern const std::string kAnvillGoto;
+
 }  // namespace anvill

--- a/include/anvill/Lifters.h
+++ b/include/anvill/Lifters.h
@@ -218,7 +218,8 @@ class LifterOptions {
         track_provenance(false),
         //TODO(ian): This should be initialized by an OS + arch pair
         stack_pointer_is_signed(false),
-        should_remove_anvill_pc(true) {
+        should_remove_anvill_pc(true),
+        should_remove_assignments_to_next_pc(false) {
     CheckModuleContextMatchesArch();
   }
 
@@ -289,6 +290,8 @@ class LifterOptions {
   bool stack_pointer_is_signed : 1;
 
   bool should_remove_anvill_pc : 1;
+
+  bool should_remove_assignments_to_next_pc : 1;
 
  private:
   LifterOptions(void) = delete;

--- a/include/anvill/Passes/RemoveAssignmentsToNextPC.h
+++ b/include/anvill/Passes/RemoveAssignmentsToNextPC.h
@@ -1,0 +1,33 @@
+
+#pragma once
+
+#include <anvill/Passes/BasicBlockPass.h>
+#include <llvm/IR/PassManager.h>
+#include <remill/BC/Util.h>
+
+#include "anvill/Lifters.h"
+
+
+namespace anvill {
+
+// attempts to replace assignments to next pc with idiomatic control flow that terminates the block
+// with the goto intrinsic
+class RemoveAssignmentsToNextPC final
+    : public BasicBlockPass<RemoveAssignmentsToNextPC> {
+ private:
+  const EntityLifter &lifter;
+
+ public:
+  RemoveAssignmentsToNextPC(const BasicBlockContexts &contexts,
+                            const EntityLifter &lifter)
+      : BasicBlockPass(contexts),
+        lifter(lifter) {}
+
+  static llvm::StringRef name(void);
+
+
+  llvm::PreservedAnalyses
+  runOnBasicBlockFunction(llvm::Function &F, llvm::FunctionAnalysisManager &AM,
+                          const anvill::BasicBlockContext &);
+};
+}  // namespace anvill

--- a/lib/ABI.cpp
+++ b/lib/ABI.cpp
@@ -87,4 +87,6 @@ const std::string kBasicBlockMetadata(kAnvillNamePrefix + "basic_block_md");
 const std::string kAnvillBasicBlockReturn(kAnvillNamePrefix +
                                           "basic_block_function_return");
 
+const std::string kAnvillGoto(kAnvillNamePrefix + "goto");
+
 }  // namespace anvill

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,7 @@ set(anvill_passes
   ReplaceStackReferences
   RemoveCallIntrinsics
   ReplaceRemillFunctionReturnsWithAnvillFunctionReturns
+  RemoveAssignmentsToNextPC
 )
 
 set(anvill_arch_HEADERS

--- a/lib/Optimize.cpp
+++ b/lib/Optimize.cpp
@@ -293,8 +293,9 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module,
   AddTransformRemillJumpIntrinsics(second_fpm, xr);
   second_fpm.addPass(llvm::VerifierPass());
   second_fpm.addPass(anvill::ReplaceStackReferences(contexts, lifter));
-  // TODO(Ian): this shouldnt be enabled by default, clients should be able to run this afterwards only if they want it since it breaks inlining.
-  second_fpm.addPass(anvill::RemoveAssignmentsToNextPC(contexts, lifter));
+  if (options.should_remove_assignments_to_next_pc) {
+    second_fpm.addPass(anvill::RemoveAssignmentsToNextPC(contexts, lifter));
+  }
   //AddRemoveRemillFunctionReturns(second_fpm, xr);
   //AddConvertSymbolicReturnAddressToConcreteReturnAddress(second_fpm);
   AddLowerRemillUndefinedIntrinsics(second_fpm);

--- a/lib/Optimize.cpp
+++ b/lib/Optimize.cpp
@@ -293,6 +293,7 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module,
   AddTransformRemillJumpIntrinsics(second_fpm, xr);
   second_fpm.addPass(llvm::VerifierPass());
   second_fpm.addPass(anvill::ReplaceStackReferences(contexts, lifter));
+  // TODO(Ian): this shouldnt be enabled by default, clients should be able to run this afterwards only if they want it since it breaks inlining.
   second_fpm.addPass(anvill::RemoveAssignmentsToNextPC(contexts, lifter));
   //AddRemoveRemillFunctionReturns(second_fpm, xr);
   //AddConvertSymbolicReturnAddressToConcreteReturnAddress(second_fpm);

--- a/lib/Optimize.cpp
+++ b/lib/Optimize.cpp
@@ -73,6 +73,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "anvill/Passes/RemoveAssignmentsToNextPC.h"
 #include "anvill/Specification.h"
 
 namespace anvill {
@@ -292,6 +293,7 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module,
   AddTransformRemillJumpIntrinsics(second_fpm, xr);
   second_fpm.addPass(llvm::VerifierPass());
   second_fpm.addPass(anvill::ReplaceStackReferences(contexts, lifter));
+  second_fpm.addPass(anvill::RemoveAssignmentsToNextPC(contexts, lifter));
   //AddRemoveRemillFunctionReturns(second_fpm, xr);
   //AddConvertSymbolicReturnAddressToConcreteReturnAddress(second_fpm);
   AddLowerRemillUndefinedIntrinsics(second_fpm);

--- a/lib/Passes/RemoveAssignmentsToNextPC.cpp
+++ b/lib/Passes/RemoveAssignmentsToNextPC.cpp
@@ -1,0 +1,109 @@
+#include <anvill/Passes/RemoveAssignmentsToNextPC.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Instruction.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/IR/PatternMatch.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <optional>
+
+#include "anvill/ABI.h"
+
+namespace anvill {
+
+llvm::StringRef RemoveAssignmentsToNextPC::name(void) {
+  return "Replace stack references";
+}
+
+
+namespace {
+std::optional<llvm::StoreInst *>
+UniqueAssignmentToNextPc(llvm::Function *func) {
+  auto target_arg = remill::NthArgument(func, remill::kNumBlockArgs);
+
+  if (target_arg->getNumUses() == 1) {
+    if (auto *user =
+            llvm::dyn_cast<llvm::StoreInst>(*target_arg->user_begin())) {
+      return user;
+    }
+  }
+
+  return std::nullopt;
+}
+
+std::optional<llvm::ReturnInst *> UniqueReturn(llvm::Function *func) {
+  std::optional<llvm::ReturnInst *> r = std::nullopt;
+  for (auto &insn : llvm::instructions(func)) {
+    if (auto nret = llvm::dyn_cast<llvm::ReturnInst>(&insn)) {
+      if (r) {
+        return std::nullopt;
+      } else {
+        r = nret;
+      }
+    }
+  }
+
+  return r;
+}
+
+llvm::Function *GetOrCreateGotoInstrinsic(llvm::Module *mod,
+                                          llvm::IntegerType *addr_ty) {
+  auto fun = mod->getFunction(anvill::kAnvillGoto);
+  if (fun) {
+    return fun;
+  }
+  auto tgt_type = llvm::FunctionType::get(
+      llvm::Type::getVoidTy(mod->getContext()), {addr_ty}, true);
+
+
+  return llvm::Function::Create(tgt_type, llvm::GlobalValue::ExternalLinkage,
+                                anvill::kAnvillGoto, mod);
+}
+
+}  // namespace
+
+namespace pats = llvm::PatternMatch;
+llvm::PreservedAnalyses RemoveAssignmentsToNextPC::runOnBasicBlockFunction(
+    llvm::Function &F, llvm::FunctionAnalysisManager &AM,
+    const anvill::BasicBlockContext &) {
+  auto next_pc_assign = UniqueAssignmentToNextPc(&F);
+  auto maybe_unique_ret = UniqueReturn(&F);
+  if (!next_pc_assign || !maybe_unique_ret) {
+    return llvm::PreservedAnalyses::all();
+  }
+
+  auto unique_ret = *maybe_unique_ret;
+
+
+  auto stored = (*next_pc_assign)->getValueOperand();
+  // now we have threes cases we can handle: constant in which case terminate with a goto, select on constant, create a terminating if goto,
+  // non constant (now we could try to recover a jump table here, but instead just switch on the stored pc value)
+  // TODO(Ian): we may be able to use the jump table analysis here to recover more idiomatic switching.. we are essentially re-doing anvill complete switch here
+  llvm::ConstantInt *first{nullptr};
+  llvm::ConstantInt *second{nullptr};
+  llvm::Value *condition{nullptr};
+
+  auto goto_instrinsic = GetOrCreateGotoInstrinsic(
+      F.getParent(), this->lifter.Options().arch->AddressType());
+  if (pats::match(stored, pats::m_ConstantInt(first))) {
+    llvm::IRBuilder<> ir(unique_ret);
+    ir.CreateCall(goto_instrinsic, {first});
+    (*next_pc_assign)->eraseFromParent();
+  } else if (pats::match(stored, pats::m_Select(pats::m_Value(condition),
+                                                pats::m_ConstantInt(first),
+                                                pats::m_ConstantInt(second)))) {
+  } else {
+  }
+
+  CHECK(!llvm::verifyFunction(F, &llvm::errs()));
+  return llvm::PreservedAnalyses::none();
+}
+
+}  // namespace anvill

--- a/lib/Passes/RemoveAssignmentsToNextPC.cpp
+++ b/lib/Passes/RemoveAssignmentsToNextPC.cpp
@@ -100,7 +100,10 @@ llvm::PreservedAnalyses RemoveAssignmentsToNextPC::runOnBasicBlockFunction(
   } else if (pats::match(stored, pats::m_Select(pats::m_Value(condition),
                                                 pats::m_Constant(first),
                                                 pats::m_Constant(second)))) {
+
   } else {
+    // not supported yet
+    return llvm::PreservedAnalyses::all();
   }
 
   CHECK(!llvm::verifyFunction(F, &llvm::errs()));

--- a/lib/Passes/RemoveAssignmentsToNextPC.cpp
+++ b/lib/Passes/RemoveAssignmentsToNextPC.cpp
@@ -1,3 +1,4 @@
+#include <anvill/ABI.h>
 #include <anvill/Passes/RemoveAssignmentsToNextPC.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
@@ -15,8 +16,6 @@
 #include <remill/BC/Util.h>
 
 #include <optional>
-
-#include "anvill/ABI.h"
 
 namespace anvill {
 


### PR DESCRIPTION
This is a temporary measure and will be superseded by #349. For now we call an intrinsic that signals a goto to address