### PR TITLE
Force pack lives to occur before recovered anvill returns when replacing remill returns

### DIFF
--- a/lib/Passes/RemoveAssignmentsToNextPC.cpp
+++ b/lib/Passes/RemoveAssignmentsToNextPC.cpp
@@ -17,6 +17,8 @@
 
 #include <optional>
 
+#include "Utils.h"
+
 namespace anvill {
 
 llvm::StringRef RemoveAssignmentsToNextPC::name(void) {
@@ -39,20 +41,6 @@ UniqueAssignmentToNextPc(llvm::Function *func) {
   return std::nullopt;
 }
 
-std::optional<llvm::ReturnInst *> UniqueReturn(llvm::Function *func) {
-  std::optional<llvm::ReturnInst *> r = std::nullopt;
-  for (auto &insn : llvm::instructions(func)) {
-    if (auto nret = llvm::dyn_cast<llvm::ReturnInst>(&insn)) {
-      if (r) {
-        return std::nullopt;
-      } else {
-        r = nret;
-      }
-    }
-  }
-
-  return r;
-}
 
 llvm::Function *GetOrCreateGotoInstrinsic(llvm::Module *mod,
                                           llvm::IntegerType *addr_ty) {

--- a/lib/Passes/ReplaceRemillFunctionReturnsWithAnvillFunctionReturns.cpp
+++ b/lib/Passes/ReplaceRemillFunctionReturnsWithAnvillFunctionReturns.cpp
@@ -40,6 +40,8 @@ ReplaceRemillFunctionReturnsWithAnvillFunctionReturns::runOnBasicBlockFunction(
   }
 
 
+  auto unique_ret = UniqueReturn(&F);
+
   ValueDecl ret_decl = bbcont.ReturnValue();
   remill::IntrinsicTable intrinsics(F.getParent());
   auto pres_analyses = llvm::PreservedAnalyses::all();
@@ -48,7 +50,10 @@ ReplaceRemillFunctionReturnsWithAnvillFunctionReturns::runOnBasicBlockFunction(
     auto mem = rep->getArgOperand(2);
     llvm::IRBuilder<> ir(rep);
     ir.SetInsertPoint(rep);
-
+    // TODO(Ian): assumes the block is terminated by a ret... what about conditional returns
+    if (unique_ret && to_replace.size() == 1) {
+      ir.SetInsertPoint(*unique_ret);
+    }
 
     std::vector<llvm::Value *> args;
 

--- a/lib/Passes/Utils.cpp
+++ b/lib/Passes/Utils.cpp
@@ -245,4 +245,19 @@ llvm::Function *GetOrCreateAnvillReturnFunc(llvm::Module *mod) {
                                 anvill::kAnvillBasicBlockReturn, mod);
 }
 
+std::optional<llvm::ReturnInst *> UniqueReturn(llvm::Function *func) {
+  std::optional<llvm::ReturnInst *> r = std::nullopt;
+  for (auto &insn : llvm::instructions(func)) {
+    if (auto nret = llvm::dyn_cast<llvm::ReturnInst>(&insn)) {
+      if (r) {
+        return std::nullopt;
+      } else {
+        r = nret;
+      }
+    }
+  }
+
+  return r;
+}
+
 }  // namespace anvill

--- a/lib/Passes/Utils.h
+++ b/lib/Passes/Utils.h
@@ -78,4 +78,6 @@ llvm::Function *AddressOfReturnAddressFunction(llvm::Module *module);
 
 llvm::Function *GetOrCreateAnvillReturnFunc(llvm::Module *module);
 
+std::optional<llvm::ReturnInst *> UniqueReturn(llvm::Function *func);
+
 }  // namespace anvill


### PR DESCRIPTION
This is a hack to better support the semantics of returns, in reality what we want here is for every block exiting control flow effect to be preceded by a live variable pack, maybe this can be achieved in #349 