### PR TITLE
Recover externals' names

### DIFF
--- a/lib/Optimize.cpp
+++ b/lib/Optimize.cpp
@@ -113,16 +113,6 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module) {
     LOG(FATAL) << remill::GetErrorString(err);
   }
 
-  if (auto used = module.getGlobalVariable("llvm.used"); used) {
-    used->setLinkage(llvm::GlobalValue::PrivateLinkage);
-    used->eraseFromParent();
-  }
-
-  if (auto used = module.getGlobalVariable("llvm.compiler.used"); used) {
-    used->setLinkage(llvm::GlobalValue::PrivateLinkage);
-    used->eraseFromParent();
-  }
-
   LOG(INFO) << "Optimizing module.";
 
   if (auto memory_escape = module.getFunction(kMemoryPointerEscapeFunction)) {
@@ -268,6 +258,16 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module) {
   fam.clear();
   cam.clear();
   lam.clear();
+
+  if (auto used = module.getGlobalVariable("llvm.used"); used) {
+    used->setLinkage(llvm::GlobalValue::PrivateLinkage);
+    used->eraseFromParent();
+  }
+
+  if (auto used = module.getGlobalVariable("llvm.compiler.used"); used) {
+    used->setLinkage(llvm::GlobalValue::PrivateLinkage);
+    used->eraseFromParent();
+  }
 
   CHECK(remill::VerifyModule(&module));
 }


### PR DESCRIPTION
Keeping values used until the optimizations run help recover the external references.

Some calls are still getting optimized away (especially when the return values are not used), but I haven't been able to figure out why that happens