### PR TITLE
Keep memory consistent through basic block calls and returns

### DIFF
--- a/lib/Lifters/BasicBlockLifter.cpp
+++ b/lib/Lifters/BasicBlockLifter.cpp
@@ -13,6 +13,7 @@
 #include <llvm/IR/Verifier.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <remill/Arch/Arch.h>
+#include <remill/BC/ABI.h>
 #include <remill/BC/InstructionLifter.h>
 #include <remill/BC/Util.h>
 
@@ -739,6 +740,8 @@ llvm::CallInst *BasicBlockLifter::ControlFlowCallBasicBlockFunction(
   std::transform(caller->arg_begin(), caller->arg_end(),
                  std::back_inserter(args),
                  [](llvm::Argument &arg) -> llvm::Value * { return &arg; });
+
+  args[remill::kMemoryPointerArgNum] = memory_pointer;
 
   auto retval = builder.CreateCall(bb_func, args);
   retval->setTailCall(true);

--- a/lib/Lifters/BasicBlockLifter.cpp
+++ b/lib/Lifters/BasicBlockLifter.cpp
@@ -425,6 +425,10 @@ BasicBlockFunction BasicBlockLifter::CreateBasicBlockFunction() {
   auto pc = remill::NthArgument(func, remill::kPCArgNum);
 
   memory->setName("memory");
+  memory->addAttr(
+      llvm::Attribute::get(llvm_context, llvm::Attribute::AttrKind::NoAlias));
+  memory->addAttr(
+      llvm::Attribute::get(llvm_context, llvm::Attribute::AttrKind::NoCapture));
   pc->setName("program_counter");
   state->setName("stack");
 
@@ -461,7 +465,12 @@ BasicBlockFunction BasicBlockLifter::CreateBasicBlockFunction() {
   auto should_return = ir.CreateAlloca(llvm::IntegerType::getInt1Ty(context),
                                        nullptr, "should_return");
   ir.CreateStore(llvm::ConstantInt::getFalse(context), should_return);
-  ir.CreateStore(memory, ir.CreateAlloca(memory->getType(), nullptr, "MEMORY"));
+  auto lded_mem =
+      ir.CreateLoad(llvm::PointerType::get(this->llvm_context, 0), memory);
+
+  ir.CreateStore(lded_mem,
+                 ir.CreateAlloca(llvm::PointerType::get(this->llvm_context, 0),
+                                 nullptr, "MEMORY"));
 
   this->state_ptr =
       this->AllocateAndInitializeStateStructure(&blk, options.arch);
@@ -547,6 +556,9 @@ BasicBlockFunction BasicBlockLifter::CreateBasicBlockFunction() {
 
   BasicBlockFunction bbf{func, pc_arg, mem_arg, next_pc, state};
 
+
+  ir.CreateStore(ret_mem, memory);
+  ir.CreateStore(ret_mem, remill::LoadMemoryPointerRef(ir.GetInsertBlock()));
   TerminateBasicBlockFunction(func, ir, ret_mem, should_return, bbf);
 
   return bbf;
@@ -740,8 +752,6 @@ llvm::CallInst *BasicBlockLifter::ControlFlowCallBasicBlockFunction(
   std::transform(caller->arg_begin(), caller->arg_end(),
                  std::back_inserter(args),
                  [](llvm::Argument &arg) -> llvm::Value * { return &arg; });
-
-  args[remill::kMemoryPointerArgNum] = memory_pointer;
 
   auto retval = builder.CreateCall(bb_func, args);
   retval->setTailCall(true);

--- a/lib/Lifters/FunctionLifter.cpp
+++ b/lib/Lifters/FunctionLifter.cpp
@@ -499,10 +499,10 @@ llvm::Function *FunctionLifter::LiftFunction(const FunctionDecl &decl) {
   //       How should control flow redirection behave in this case?
   auto &entry_lifter = this->GetOrCreateBasicBlockLifter(this->func_address);
 
-  auto memptr = remill::LoadMemoryPointer(ir, this->intrinsics);
-
   auto call_inst = entry_lifter.CallBasicBlockFunction(
-      ir, lifted_func_st.state_ptr, abstract_stack, memptr);
+      ir, lifted_func_st.state_ptr, abstract_stack, this->mem_ptr_ref);
+
+  auto memptr = remill::LoadMemoryPointer(ir, this->intrinsics);
 
   if (!call_inst->getType()->isVoidTy()) {
     // TODO(Ian): this memptr is not right


### PR DESCRIPTION
Current tail calls dont pass the up to date memory pointer to the child block. We could fix this by just passing the resulting memory down to children, but this would not help for blocks that only native return. These blocks (if there is no memory read for the return value ie. if there is just a global write) can discard memory writes. This PR transforms memory writes to write into a memory ref hosted in the parent function. 

Im concerned that in the high level lift we may run into a similar issue, but lets deal with the immediate problem first