### PR TITLE
Ian/allow for typehints in spec

### DIFF
--- a/data_specifications/specification.proto
+++ b/data_specifications/specification.proto
@@ -305,6 +305,11 @@ message StackFrame {
   int64 parameter_offset = 5;
 }
 
+message TypeHint {
+  uint64 target_addr = 1;
+  Variable target_var = 2;
+}
+
 message Function {
   uint64 entry_address = 1;
   FunctionLinkage func_linkage = 3; 
@@ -319,6 +324,11 @@ message Function {
   StackFrame frame = 9;
 
   repeated Parameter in_scope_vars = 10;
+
+  // an instruction can have a set of typehints that says this loc is known 
+  // to have this type after this instruction, these will be translated into 
+  // a low lifting of that location with spec type metadata
+  repeated TypeHint type_hints = 11;
 }
 
 message GlobalVariable {

--- a/include/anvill/Declarations.h
+++ b/include/anvill/Declarations.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <_types/_uint64_t.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
@@ -365,6 +366,11 @@ class SpecBlockContext : public BasicBlockContext {
   virtual const std::vector<ParameterDecl> &LiveParamsAtExit() const override;
 };
 
+
+struct TypeHint {
+  uint64_t target_addr;
+  ValueDecl hint;
+};
 // A function decl, as represented at a "near ABI" level. To be specific,
 // not all C, and most C++ decls, as written would be directly translatable
 // to this. This ought nearly represent how LLVM represents a C/C++ function
@@ -414,6 +420,9 @@ struct FunctionDecl : public CallableDecl {
 
   std::unordered_map<std::uint64_t, std::vector<ConstantDomain>>
       constant_values_at_exit;
+
+  // sorted vector of hints
+  std::vector<TypeHint> type_hints;
 
   std::uint64_t stack_depth;
 

--- a/include/anvill/Declarations.h
+++ b/include/anvill/Declarations.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <_types/_uint64_t.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>

--- a/lib/Lifters/BasicBlockLifter.cpp
+++ b/lib/Lifters/BasicBlockLifter.cpp
@@ -11,7 +11,6 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Verifier.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <remill/Arch/Arch.h>
 #include <remill/BC/ABI.h>

--- a/lib/Lifters/BasicBlockLifter.cpp
+++ b/lib/Lifters/BasicBlockLifter.cpp
@@ -8,7 +8,6 @@
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
-#include <llvm/IR/Instruction.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Verifier.h>

--- a/lib/Lifters/BasicBlockLifter.h
+++ b/lib/Lifters/BasicBlockLifter.h
@@ -73,6 +73,9 @@ class BasicBlockLifter : public CodeLifter {
 
   remill::DecodingContext CreateDecodingContext(const CodeBlock &blk);
 
+
+  void ApplyTypeHint(llvm::IRBuilder<> &bldr, const ValueDecl &type_hint);
+
   void LiftInstructionsIntoLiftedFunction();
 
   BasicBlockFunction CreateBasicBlockFunction();

--- a/lib/Lifters/CodeLifter.cpp
+++ b/lib/Lifters/CodeLifter.cpp
@@ -1,6 +1,9 @@
 #include "CodeLifter.h"
 
+#include <anvill/ABI.h>
+#include <anvill/Type.h>
 #include <glog/logging.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/InstIterator.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Verifier.h>
@@ -23,8 +26,6 @@
 #include <remill/BC/Util.h>
 
 #include <unordered_set>
-
-#include "anvill/Type.h"
 
 namespace anvill {
 namespace {
@@ -168,6 +169,25 @@ void CodeLifter::InitializeStateStructureFromGlobalRegisterVariables(
       ir.CreateStore(ir.CreateLoad(reg->type, reg_global), reg_ptr);
     }
   });
+}
+
+llvm::Function *CodeLifter::GetTypeHintFunction() {
+  const auto &func_name = kTypeHintFunctionPrefix;
+
+  auto func = semantics_module->getFunction(func_name);
+  if (func != nullptr) {
+    return func;
+  }
+
+  auto ptr = llvm::PointerType::get(this->semantics_module->getContext(), 0);
+  llvm::Type *func_parameters[] = {ptr};
+
+  auto func_type = llvm::FunctionType::get(ptr, func_parameters, false);
+
+  func = llvm::Function::Create(func_type, llvm::GlobalValue::ExternalLinkage,
+                                func_name, this->semantics_module);
+
+  return func;
 }
 
 llvm::MDNode *CodeLifter::GetAddrAnnotation(uint64_t addr,

--- a/lib/Lifters/CodeLifter.h
+++ b/lib/Lifters/CodeLifter.h
@@ -72,6 +72,9 @@ class CodeLifter {
 
   unsigned pc_annotation_id;
 
+
+  llvm::Function *GetTypeHintFunction();
+
   llvm::MDNode *GetAddrAnnotation(uint64_t addr,
                                   llvm::LLVMContext &context) const;
 

--- a/lib/Optimize.cpp
+++ b/lib/Optimize.cpp
@@ -262,7 +262,6 @@ void OptimizeModule(const EntityLifter &lifter, llvm::Module &module,
   //AddRecoverBasicStackFrame(fpm, options.stack_frame_recovery_options);
   //AddSplitStackFrameAtReturnAddress(fpm, options.stack_frame_recovery_options);
   fpm.addPass(llvm::SROAPass(llvm::SROAOptions::ModifyCFG));
-  //fpm.addPass(anvill::ReplaceStackReferences(contexts, lifter));
   fpm.addPass(llvm::VerifierPass());
   fpm.addPass(llvm::SROAPass(llvm::SROAOptions::ModifyCFG));
   fpm.addPass(llvm::VerifierPass());


### PR DESCRIPTION
Adds typehints on values at a given address. The basic strategy here is to store an intrinsic hint at any low value after that instruction. The pointer lifter then converts intrinsics into metadata it can use.