### PR TITLE
Bump lifting-tools-ci to use clang-14 for SPARC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ on:
     branches:
       - "*"
 
+  workflow_dispatch:
+
 jobs:
   cleanup_stale_workflows:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
sparc seems to work, or at least not crash on any of the tests