### PR TITLE
Add bb addr to spec

### DIFF
--- a/data_specifications/specification.proto
+++ b/data_specifications/specification.proto
@@ -278,6 +278,9 @@ message CodeBlock {
   uint32 size = 5;
   map<string, uint64> context_assignments = 6;
   uint64 uid = 7;
+  // address may not correspond to actual basic-blocks
+  // so we store the real one here
+  uint64 bb_addr = 8;
 }
 
 message Variables {

--- a/include/anvill/Declarations.h
+++ b/include/anvill/Declarations.h
@@ -64,6 +64,7 @@ namespace anvill {
 
 struct CodeBlock {
   uint64_t addr;
+  uint64_t bb_addr;
   uint32_t size;
   std::unordered_set<Uid> outgoing_edges;
   // The set of context assignments that occur at the entry point to this block.

--- a/lib/Protobuf.cpp
+++ b/lib/Protobuf.cpp
@@ -652,6 +652,7 @@ void ProtobufTranslator::ParseCFGIntoFunction(
     }
     CodeBlock nblk = {
         blk.second.address(),
+        blk.second.bb_addr(),
         blk.second.size(),
         tmp,
         {blk.second.context_assignments().begin(),


### PR DESCRIPTION
Sometimes it's useful to know which basic block the code block corresponds to since code blocks aren't necessarily always the same as the basic block.